### PR TITLE
Basis für PDF Export und einige Fixes

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -23,6 +23,7 @@
 		"SpecialLoopStructure": "includes/SpecialLoopStructure.php",
 		"SpecialLoopStructureEdit": "includes/SpecialLoopStructure.php",
 		"LoopXml": "includes/LoopXml.php",
+		"LoopPdf": "includes/LoopPdf.php",
 		"LoopExport": "includes/LoopExport.php",
 		"LoopExportPdf": "includes/LoopExport.php",
 		"LoopExportXml": "includes/LoopExport.php",
@@ -122,5 +123,15 @@
 	"ExtensionMessagesFiles": {
 		"LoopAlias": "Loop.i18n.alias.php"
 	},		
+	"config": {
+        "Xmlfo2PdfServiceUrl": {
+        	"value" : "",
+        	"description" : "URL of the Service to convert XMLFO to PDF"
+        },
+        "Xmlfo2PdfServiceToken": {
+        	"value" : "",
+        	"description" : "Token for the Service to convert XMLFO to PDF"
+        }
+	}, 	
 	"manifest_version": 2
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -42,7 +42,8 @@
 	"action-loop-export-html": "Export LOOP als Offline HTML",
 	"action-loop-export-scorm": "Export LOOP als Scorm Paket",
   
-	"export-linktext-xml": "Als XML herunterladen"
+	"export-linktext-xml": "Als XML herunterladen",
+	"export-linktext-pdf": "Als PDF herunterladen"
 
 
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -41,6 +41,7 @@
 	"action-loop-export-html": "Export LOOP as Offline HTML",
 	"action-loop-export-scorm": "Export LOOP as Scorm",
 
-	"export-linktext-xml": "Download as XML"
+	"export-linktext-xml": "Download as XML",
+	"export-linktext-pdf": "Download as PDF"
 
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -41,6 +41,7 @@
 	"action-loop-export-html": "Export LOOP as Offline HTML",
 	"action-loop-export-scorm": "Export LOOP as Scorm",
 
-	"export-linktext-xml": "Linktext to download LOOP in export format XML"
+	"export-linktext-xml": "Linktext to download LOOP in export format XML",
+	"export-linktext-pdf": "Linktext to download LOOP in export format PDF"
 
 }

--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -81,14 +81,14 @@ abstract class LoopExport {
 	
 class LoopExportXml extends LoopExport {
 
-	public function LoopExportXml($structure) {
+	public function __construct($structure) {
 		$this->structure = $structure;
 		$this->exportDirectory = '/export/xml';
 		$this->fileExtension = 'xml';
 	}
 
 	public function generateExportContent() {
-		$this->exportContent = LoopXml::structure2xml();
+		$this->exportContent = LoopXml::structure2xml($this->structure);
 	}
 
 	public function sendExportHeader() {
@@ -99,6 +99,11 @@ class LoopExportXml extends LoopExport {
 		header("Content-Type: application/xml; charset=utf-8");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 
+	}
+	
+	// for Development
+	public function getExistingExportFile() {
+		return false;
 	}
 }
 
@@ -112,7 +117,7 @@ class LoopExportPdf extends LoopExport {
 	}
 
 	public function generateExportContent() {
-		$this->exportContent = ''; // ToDo: LoopPdf
+		$this->exportContent = LoopPdf::structure2pdf($this->structure);
 	}
 
 	public function sendExportHeader() {
@@ -125,12 +130,17 @@ class LoopExportPdf extends LoopExport {
 		header("Content-Length: ". strlen($this->exportContent));
 
 	}
+	
+	// for Development
+	public function getExistingExportFile() {
+		return false; 
+	}
 }
 
 
 class LoopExportMp3 extends LoopExport {
 
-	public function LoopExportMp3($structure) {
+	public function __construct($structure) {
 		$this->structure = $structure;
 		$this->exportDirectory = '/export/mp3';
 		$this->fileExtension = 'zip';
@@ -156,7 +166,7 @@ class LoopExportMp3 extends LoopExport {
 
 class LoopExportEpub extends LoopExport {
 
-	public function LoopExportEpub($structure) {
+	public function __construct($structure) {
 		$this->structure = $structure;
 		$this->exportDirectory = '/export/epub';
 		$this->fileExtension = 'epub';
@@ -180,7 +190,7 @@ class LoopExportEpub extends LoopExport {
 
 class LoopExportHtml extends LoopExport {
 
-	public function LoopExportHtml($structure) {
+	public function __construct($structure) {
 		$this->structure = $structure;
 		$this->exportDirectory = '/export/html';
 		$this->fileExtension = 'zip';
@@ -204,7 +214,7 @@ class LoopExportHtml extends LoopExport {
 
 class LoopExportScorm extends LoopExport {
 
-	public function LoopExportScorm($structure) {
+	public function __construct($structure) {
 		$this->structure = $structure;
 		$this->exportDirectory = '/export/Scorm';
 		$this->fileExtension = 'zip';

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -1,0 +1,52 @@
+<?php 
+
+class LoopPdf {
+	
+	public static function structure2pdf(LoopStructure $structure) {
+		global $IP, $wgXmlfo2PdfServiceUrl, $wgXmlfo2PdfServiceToken;
+	
+		
+	
+		$unique = uniqid();
+	
+		$wiki_xml = LoopXml::structure2xml($structure);
+	
+		try {
+			$xml = new DOMDocument();
+			$xml->loadXML($wiki_xml);
+		} catch (Exception $e) {
+			var_dump($e);
+		}
+	
+		try {
+			$xsl = new DOMDocument;
+			$xsl->load($IP.'/extensions/Loop/xsl/pdf.xsl');
+		} catch (Exception $e) {
+			var_dump($e);
+		}
+	
+		try {
+			$proc = new XSLTProcessor;
+			$proc->registerPHPFunctions();
+			$proc->importStyleSheet($xsl);
+			$xmlfo = $proc->transformToXML($xml);
+		} catch (Exception $e) {
+			var_dump($e);
+		}
+	
+		#var_dump($xmlfo);exit;
+		$url = $wgXmlfo2PdfServiceUrl. '?token='.$wgXmlfo2PdfServiceToken;
+		
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_POST, 1);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml'));
+		curl_setopt($ch, CURLOPT_POSTFIELDS, "$xmlfo");
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		$pdf = curl_exec($ch);
+		curl_close($ch);
+	
+		return $pdf;
+	
+	}	
+	
+}

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -428,6 +428,61 @@ class LoopStructureItem {
 	
 	}
 	
+
+	/**
+	 * Get item for given article and structure from database
+	 *
+	 * @param int $articleId
+	 * @param int $structure
+	 */
+	public static function newFromToctext( $toctext ) {
+	
+		$dbr = wfGetDB( DB_SLAVE );
+		$res = $dbr->select(
+				'loop_structure_items',
+				array(
+						'lsi_id',
+						'lsi_article',
+						'lsi_previous_article',
+						'lsi_next_article',
+						'lsi_parent_article',
+						'lsi_toc_level',
+						'lsi_sequence',
+						'lsi_toc_number',
+						'lsi_toc_text'
+				),
+				array(
+						'lsi_toc_text' => $toctext
+				),
+				__METHOD__,
+				array(
+						'ORDER BY' => 'lsi_sequence ASC'
+				)
+		);
+	
+		if( $row = $res->fetchObject() ) {
+	
+			$loopStructureItem = new LoopStructureItem();
+			$loopStructureItem->id = $row->lsi_id;
+			$loopStructureItem->article = $row->lsi_article;
+			$loopStructureItem->previousArticle = $row->lsi_previous_article;
+			$loopStructureItem->nextArticle = $row->lsi_next_article;
+			$loopStructureItem->parentArticle = $row->lsi_parent_article;
+			$loopStructureItem->tocLevel = $row->lsi_toc_level;
+			$loopStructureItem->sequence = $row->lsi_sequence;
+			$loopStructureItem->tocNumber = $row->lsi_toc_number;
+			$loopStructureItem->tocText = $row->lsi_toc_text;
+	
+			return $loopStructureItem;
+	
+		} else {
+	
+			return false;
+	
+		}
+	
+	}	
+	
 	public function getPreviousChapterItem () {
 		
 		$dbr = wfGetDB( DB_SLAVE );

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -191,6 +191,9 @@ class LoopStructure {
 	}
 	
 	public function getStructureItems() {
+		if (!$this->structureItems) {
+			$this->loadStructureItems();
+		}
 		return $this->structureItems;
 	}
 	

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -1,11 +1,9 @@
 <?php
 class LoopXml {
-	public static function structure2xml() {
+	public static function structure2xml(LoopStructure $loopStructure) {
 		global $wgCanonicalServer, $wgLanguageCode;
 		
-		$loopStructure = new LoopStructure ();
-		$loopStructure->loadStructureItems ();
-		$loopStructureItems = $loopStructure->getStructureItems ();		
+		$loopStructureItems = $loopStructure->getStructureItems();		
 		
 		$langParts = mb_split("-",$wgLanguageCode);
 		
@@ -39,7 +37,7 @@ class LoopXml {
 		
 		return $xml;
 	}
-	public static function structureItem2xml($structureItem) {
+	public static function structureItem2xml(LoopStructureItem $structureItem) {
 		$content = WikiPage::newFromID ( $structureItem->getArticle () )->getContent ()->getNativeData ();
 		
 		$content = html_entity_decode($content);
@@ -57,7 +55,7 @@ class LoopXml {
 	}
 	
 	
-	private static function structureItemToc($structureItem) {
+	private static function structureItemToc(LoopStructureItem $structureItem) {
 		$toc_xml = "<chapter>";
 	
 		$childs = $structureItem->getDirectChildItems();

--- a/includes/SpecialLoopExport.php
+++ b/includes/SpecialLoopExport.php
@@ -67,10 +67,19 @@ class SpecialLoopExport extends SpecialPage {
 			echo $export->getExportContent();
 		} else {
 			
+			$out->addHtml('<ul>');
+			
 			if ($user->isAllowed( 'loop-export-xml' )) {
 				$xmlExportLink = Linker::link( new TitleValue( NS_SPECIAL, 'LoopExport/xml' ), wfMessage ( 'export-linktext-xml' )->inContentLanguage ()->text () ); 
-				$out->addHtml ($xmlExportLink);
+				$out->addHtml ('<li>'.$xmlExportLink.'</li>');
 			}
+			
+			if ($user->isAllowed( 'loop-export-pdf' )) {
+				$pdfExportLink = Linker::link( new TitleValue( NS_SPECIAL, 'LoopExport/pdf' ), wfMessage ( 'export-linktext-pdf' )->inContentLanguage ()->text () );
+				$out->addHtml ('<li>'.$pdfExportLink.'</li>');
+			}
+			
+			$out->addHtml('</ul>');
 			
 		}
 	}

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2004/07/xpath-functions"
+	xmlns:xdt="http://www.w3.org/2004/07/xpath-datatypes" xmlns:fox="http://xml.apache.org/fop/extensions"
+	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:exsl="http://exslt.org/common"
+	xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:func="http://exslt.org/functions"
+	xmlns:php="http://php.net/xsl" xmlns:str="http://exslt.org/strings"
+	xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+	extension-element-prefixes="func php str" xmlns:functx="http://www.functx.com" exclude-result-prefixes="xhtml">
+
+	<xsl:import href="pdf_params.xsl"></xsl:import>
+	<xsl:import href="pdf_terms.xsl"></xsl:import>	
+		
+	<xsl:output method="xml" version="1.0" encoding="UTF-8"
+		indent="yes"></xsl:output>
+
+	<xsl:variable name="lang">
+		<xsl:value-of select="/loop/meta/lang"></xsl:value-of>
+	</xsl:variable>
+	
+	<xsl:template match="loop">
+		<fo:root>
+			<xsl:attribute name="hyphenate">true</xsl:attribute>
+			<fo:layout-master-set>
+				<fo:simple-page-master master-name="cover-page"
+					page-height="{$pageheight}" page-width="{$pagewidth}" margin-top="10mm"
+					margin-bottom="10mm" margin-left="25mm" margin-right="15mm">
+					<fo:region-body margin-top="10mm" margin-bottom="15mm" />
+				</fo:simple-page-master>
+				<fo:simple-page-master master-name="full-page"
+					page-height="{$pageheight}" page-width="{$pagewidth}" margin-top="10mm"
+					margin-bottom="5mm" margin-left="25mm" margin-right="15mm">
+					<fo:region-body margin-top="15mm" margin-bottom="15mm" />
+					<fo:region-before extent="20mm" />
+					<fo:region-after extent="15mm" />
+				</fo:simple-page-master>
+				<fo:simple-page-master master-name="default-page"
+					page-height="{$pageheight}" page-width="{$pagewidth}" margin-top="10mm"
+					margin-bottom="5mm" margin-left="25mm" margin-right="15mm">
+					<fo:region-body margin-top="15mm" margin-bottom="15mm"
+						margin-left="20mm"/>
+					<fo:region-before extent="20mm" />
+					<fo:region-after extent="15mm" />
+				</fo:simple-page-master>
+				<fo:simple-page-master master-name="full-page-2column"
+					page-height="{$pageheight}" page-width="{$pagewidth}" margin-top="10mm"
+					margin-bottom="5mm" margin-left="25mm" margin-right="15mm">
+					<fo:region-body margin-top="15mm" margin-bottom="15mm" column-count="2" column-gap="10mm"/>
+					<fo:region-before extent="20mm" />
+					<fo:region-after extent="15mm" />
+				</fo:simple-page-master>				
+			</fo:layout-master-set>
+			
+			<xsl:call-template name="page-sequence-cover"></xsl:call-template>		
+		
+		</fo:root>
+	</xsl:template>
+	
+	
+	<!-- Page Sequence für Cover-Page -->
+	<xsl:template name="page-sequence-cover">
+		<fo:page-sequence master-reference="cover-page" id="cover_sequence">
+			<fo:flow font-family="{$font_family}" flow-name="xsl-region-body">
+				<xsl:call-template name="page-content-cover"></xsl:call-template>
+			</fo:flow>
+		</fo:page-sequence>
+	</xsl:template>	
+	
+	<!-- Page Content der Cover-Page -->
+	<xsl:template name="page-content-cover">
+		<fo:block text-align="right" font-size="26pt" font-weight="bold"
+			id="cover" margin-bottom="10mm" margin-top="40mm" hyphenate="false">
+			<xsl:value-of select="/loop/meta/title"></xsl:value-of>
+		</fo:block>
+		<fo:block text-align="right" font-size="14pt" font-weight="normal"
+			margin-bottom="5mm">
+			<xsl:value-of select="/loop/meta/url"></xsl:value-of>
+		</fo:block>
+		<fo:block text-align="right" font-size="12pt" margin-bottom="10mm">
+			<xsl:value-of select="$word_state"></xsl:value-of>
+			<xsl:text> </xsl:text>
+			<xsl:value-of select="/loop/meta/date_generated"></xsl:value-of>
+		</fo:block>
+		
+	</xsl:template>	
+	
+</xsl:stylesheet>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2004/07/xpath-functions"
 	xmlns:xdt="http://www.w3.org/2004/07/xpath-datatypes" xmlns:fox="http://xml.apache.org/fop/extensions"
@@ -52,10 +52,23 @@
 				</fo:simple-page-master>				
 			</fo:layout-master-set>
 			
-			<xsl:call-template name="page-sequence-cover"></xsl:call-template>		
+			<xsl:call-template name="make-declarations"></xsl:call-template>
+			
+			<xsl:call-template name="page-sequence-cover"></xsl:call-template>	
+			<xsl:call-template name="page-sequence-table-of-content"></xsl:call-template>
+			<xsl:call-template name="page-sequence-contentpages"></xsl:call-template>				
 		
 		</fo:root>
 	</xsl:template>
+	
+	
+	<xsl:template name="make-declarations">
+		<axf:document-info name="document-title" >
+			<xsl:attribute name="value"><xsl:value-of select="/loop/meta/title"></xsl:value-of></xsl:attribute>
+		</axf:document-info>
+		
+		<!-- ToDo: add more infos, see https://www.antennahouse.com/product/ahf65/ahf-ext.html#axf.document-info -->
+	</xsl:template>		
 	
 	
 	<!-- Page Sequence für Cover-Page -->
@@ -82,6 +95,389 @@
 			<xsl:text> </xsl:text>
 			<xsl:value-of select="/loop/meta/date_generated"></xsl:value-of>
 		</fo:block>
+		
+	</xsl:template>	
+	
+	
+	<!-- Page Sequence für Inhaltsverzeichnis -->
+	<xsl:template name="page-sequence-table-of-content">
+		<fo:page-sequence master-reference="full-page"
+			id="table_of_content_sequence">
+			<fo:static-content font-family="{$font_family}"
+				flow-name="xsl-region-before">
+				<xsl:call-template name="default-header"></xsl:call-template>
+			</fo:static-content>
+			<fo:static-content font-family="{$font_family}"
+				flow-name="xsl-region-after">
+				<xsl:call-template name="default-footer"></xsl:call-template>
+			</fo:static-content>
+			<fo:flow font-family="{$font_family}" flow-name="xsl-region-body"
+				text-align="justify" font-size="11.5pt" line-height="15.5pt"
+				orphans="3">
+				<xsl:call-template name="page-content-table-of-content"></xsl:call-template>
+			</fo:flow>
+		</fo:page-sequence>
+	</xsl:template>	
+	
+	<!-- Page Content des Inhaltsverzeichnises -->
+	<xsl:template name="page-content-table-of-content">
+		<fo:block>
+			<fo:marker marker-class-name="page-title-left">
+				<xsl:value-of select="//loop/meta/title"></xsl:value-of>
+			</fo:marker>
+		</fo:block>
+		<fo:block>
+			<fo:marker marker-class-name="page-title-right">
+				<xsl:value-of select="$word_content"></xsl:value-of>
+			</fo:marker>
+		</fo:block>
+		<fo:block id="table_of_content">
+			<xsl:call-template name="font_head"></xsl:call-template>
+			<xsl:value-of select="$word_content"></xsl:value-of>
+		</fo:block>
+		
+		<xsl:call-template name="make-toc"></xsl:call-template>	
+		
+	</xsl:template>		
+	
+	
+	<xsl:template name="make-toc">
+		<xsl:apply-templates select="toc"  mode="toc"></xsl:apply-templates>
+	</xsl:template>
+	
+	<xsl:template match="toc" mode="toc">
+		<xsl:apply-templates select="chapter"  mode="toc"></xsl:apply-templates>
+	</xsl:template>
+	
+	<xsl:template match="chapter" mode="toc">
+		<xsl:apply-templates select="page"  mode="toc"></xsl:apply-templates>
+	</xsl:template>
+
+	<xsl:template match="page" mode="toc">
+		<fo:block text-align-last="justify">
+			<xsl:call-template name="font_normal"></xsl:call-template>	
+			<xsl:if test="@toclevel &gt; 0">
+				<xsl:attribute name="margin-left">
+					<xsl:value-of select="@toclevel - 1"></xsl:value-of><xsl:text>em</xsl:text>
+				</xsl:attribute>
+			</xsl:if>
+			
+
+			<fo:basic-link color="black">
+				<xsl:attribute name="internal-destination" >
+				<!--  <xsl:value-of select="@title"></xsl:value-of>
+				<xsl:value-of select="generate-id()"/> -->
+				<xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
+				<xsl:value-of select="@tocnumber"></xsl:value-of>
+				<xsl:text> </xsl:text>
+				<xsl:value-of select="@toctext"></xsl:value-of>
+			</fo:basic-link>
+			<fo:inline keep-together.within-line="always">
+				<fo:leader leader-pattern="dots"></fo:leader>
+				<fo:page-number-citation>
+					<xsl:attribute name="ref-id" >
+					<!-- <xsl:value-of select="@title"></xsl:value-of>
+					<xsl:value-of select="generate-id()"/> -->
+					<xsl:value-of select="@id"></xsl:value-of>			
+					</xsl:attribute>
+				</fo:page-number-citation>
+			</fo:inline>				
+		</fo:block>
+		<xsl:apply-templates select="chapter"  mode="toc"></xsl:apply-templates>	
+		
+		
+		
+	</xsl:template>			
+	
+	<!-- Page Sequence für Wiki-Seiten -->
+	<xsl:template name="page-sequence-contentpages">
+		<fo:page-sequence master-reference="default-page"
+			id="contentpages_sequence">
+			<fo:static-content font-family="{$font_family}"
+				flow-name="xsl-region-before">
+				<xsl:call-template name="default-header"></xsl:call-template>
+			</fo:static-content>
+			<fo:static-content font-family="{$font_family}"
+				flow-name="xsl-region-after">
+				<xsl:call-template name="default-footer"></xsl:call-template>
+			</fo:static-content>
+			<fo:flow font-family="{$font_family}" flow-name="xsl-region-body"
+				text-align="justify" font-size="11.5pt" line-height="15.5pt"
+				orphans="3">
+				<xsl:call-template name="page-content-contentpages"></xsl:call-template>
+			</fo:flow>
+		</fo:page-sequence>
+	</xsl:template>
+
+	<!-- Page Content einer Wiki-Seite -->
+	<xsl:template name="page-content-contentpages">
+		<xsl:apply-templates select="articles/article"></xsl:apply-templates>
+	</xsl:template>	
+	
+	<!-- Page Content einer Wiki-Seite -->
+	<xsl:template match="article">
+		<xsl:variable name="toclevel" select="@toclevel"></xsl:variable>
+		<xsl:choose>
+			<xsl:when test="@toclevel=''">
+				<xsl:apply-templates></xsl:apply-templates>
+			</xsl:when>
+			<xsl:otherwise>
+		<fo:block >
+			<xsl:attribute name="id">
+				<!-- <xsl:value-of select="generate-id()"></xsl:value-of> -->
+				<xsl:value-of select="@id"></xsl:value-of>
+			</xsl:attribute>
+			<xsl:choose>
+				<xsl:when test="$toclevel &lt; 2"> 
+					<xsl:attribute name="break-before">page</xsl:attribute>
+				</xsl:when>
+				<xsl:otherwise>
+					<fo:block margin-top="10mm">
+					</fo:block>		
+				</xsl:otherwise>
+			</xsl:choose>
+			<fo:block>
+				<fo:marker marker-class-name="page-title-left">
+				<xsl:choose>
+					<xsl:when test="@toclevel=0">
+						<xsl:value-of select="//loop/@title"></xsl:value-of>
+					</xsl:when>
+					<xsl:when test="@toclevel=1">
+						<xsl:value-of select="//loop/@title"></xsl:value-of>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:value-of select="preceding-sibling::node()[@toclevel &lt; $toclevel][1]/@tocnumber"></xsl:value-of>
+						<xsl:text> </xsl:text>
+						<xsl:value-of select="preceding-sibling::node()[@toclevel &lt; $toclevel][1]/@toctext"></xsl:value-of>
+					</xsl:otherwise>					
+				</xsl:choose>
+				</fo:marker>
+			</fo:block>
+			<fo:block>
+				<fo:marker marker-class-name="page-title-right">
+					<xsl:value-of select="@tocnumber"></xsl:value-of>
+					<xsl:text> </xsl:text>
+					<xsl:choose>
+						<xsl:when test="string-length(@toctext) &gt; 63">
+							<xsl:value-of select="concat(substring(@toctext,0,60),'...')"></xsl:value-of>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="@toctext"></xsl:value-of>
+						</xsl:otherwise>
+					</xsl:choose>
+				</fo:marker>
+			</fo:block>
+			<fo:block keep-with-next.within-page="always">
+				<xsl:call-template name="font_head"></xsl:call-template>
+				<xsl:value-of select="@tocnumber"></xsl:value-of>
+				<xsl:text> </xsl:text>
+				<xsl:value-of select="@toctext"></xsl:value-of>
+			</fo:block>
+			<fo:block keep-with-previous.within-page="always">
+				<xsl:call-template name="font_normal"></xsl:call-template>
+				<xsl:apply-templates></xsl:apply-templates>
+			</fo:block>
+		</fo:block>
+
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>	
+	
+	
+	
+	
+	
+	
+	<!-- Default Header -->
+	<xsl:template name="default-header">
+		<fo:table table-layout="fixed" width="100%" margin-bottom="2mm">
+			<fo:table-body>
+				<fo:table-row>
+					<fo:table-cell text-align="left">
+						<fo:block line-height="13pt" margin-bottom="-3mm"
+							font-weight="bold">
+							<fo:retrieve-marker retrieve-class-name="page-title-left"
+								retrieve-position="first-starting-within-page"
+								retrieve-boundary="page-sequence"></fo:retrieve-marker>
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell text-align="right">
+						<fo:block line-height="13pt" margin-bottom="-3mm">
+							<fo:retrieve-marker retrieve-class-name="page-title-right"
+								retrieve-position="first-including-carryover" retrieve-boundary="page-sequence"></fo:retrieve-marker>
+						</fo:block>
+					</fo:table-cell>
+				</fo:table-row>
+			</fo:table-body>
+		</fo:table>
+		<fo:block>
+			<fo:leader leader-pattern="rule" leader-length="100%"
+				rule-thickness="0.5pt" rule-style="solid" color="black"
+				display-align="after"></fo:leader>
+		</fo:block>
+	</xsl:template>	
+	
+	<!-- Default Footer -->
+	<xsl:template name="default-footer">
+		<xsl:param name="last-page-sequence-name">
+			<xsl:call-template name="last-page-sequence-name"></xsl:call-template>
+		</xsl:param>
+		<fo:block>
+			<fo:leader leader-pattern="rule" leader-length="100%"
+				rule-thickness="0.5pt" rule-style="solid" color="black"
+				display-align="before"></fo:leader>
+		</fo:block>
+		<fo:block text-align="right">
+			<fo:page-number></fo:page-number>
+			/
+			<fo:page-number-citation-last ref-id="{$last-page-sequence-name}"></fo:page-number-citation-last>
+		</fo:block>
+	</xsl:template>
+		
+	<xsl:template name="last-page-sequence-name">
+		<xsl:text>contentpages_sequence</xsl:text>		
+	</xsl:template>
+	
+	
+	
+<xsl:template name="font_icon">
+		<xsl:attribute name="font-size" >8.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight" >bold</xsl:attribute>
+		<xsl:attribute name="line-height" >12pt</xsl:attribute>
+		<xsl:attribute name="margin-bottom" >1mm</xsl:attribute>
+	</xsl:template>	
+
+	<xsl:template name="font_small">
+		<xsl:attribute name="font-size">9.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">normal</xsl:attribute>
+		<xsl:attribute name="line-height">12.5pt</xsl:attribute>
+	</xsl:template>
+	<xsl:template name="font_normal">
+		<xsl:attribute name="font-size">11.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">normal</xsl:attribute>
+		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
+	</xsl:template>
+	<xsl:template name="font_big">
+		<xsl:attribute name="font-size">12.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">normal</xsl:attribute>
+		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
+	</xsl:template>	
+	<xsl:template name="font_subsubhead">
+		<xsl:attribute name="font-size">11.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
+		<xsl:attribute name="margin-top">7pt</xsl:attribute>
+	</xsl:template>
+	<xsl:template name="font_subhead">
+		<xsl:attribute name="font-size">13.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+		<xsl:attribute name="line-height">15.5pt</xsl:attribute>
+		<xsl:attribute name="margin-top">7pt</xsl:attribute>
+	</xsl:template>
+	<xsl:template name="font_head">
+		<xsl:attribute name="font-size">14.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+		<xsl:attribute name="line-height">16.5pt</xsl:attribute>
+		<xsl:attribute name="margin-top">7pt</xsl:attribute>
+	</xsl:template>	
+	
+	<xsl:template name="font_object_title">
+		<xsl:attribute name="font-size">9.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">normal</xsl:attribute>
+		<xsl:attribute name="line-height">12.5pt</xsl:attribute>
+	</xsl:template>	
+	
+	<xsl:template match="paragraph">
+		<fo:block margin-top="7pt">
+			<xsl:call-template name="font_normal"></xsl:call-template>
+			<xsl:apply-templates></xsl:apply-templates>
+		</fo:block>
+	</xsl:template>
+	
+	<xsl:template match="preblock" >
+		<xsl:apply-templates></xsl:apply-templates>
+	</xsl:template>
+
+	<xsl:template match="preline" >
+		<fo:block font-family="{$font_family}">
+	    	<xsl:apply-templates></xsl:apply-templates>
+    	</fo:block>
+	</xsl:template>		
+	
+	<xsl:template match="space">
+		<xsl:text> </xsl:text>
+	</xsl:template>		
+	
+	
+	<xsl:template match="link">
+		<xsl:apply-templates select="php:function('LoopXml::transform_link', .)"></xsl:apply-templates>
+	</xsl:template> 
+	
+<xsl:template match="php_link">
+		<xsl:value-of select="."></xsl:value-of>
+	</xsl:template>
+	
+	<xsl:template match="php_link_external">
+		<fo:basic-link>
+			<xsl:attribute name="external-destination"><xsl:value-of select="@href"></xsl:value-of></xsl:attribute>
+			<fo:inline text-decoration="underline"><xsl:value-of select="."></xsl:value-of></fo:inline>
+			<xsl:text> </xsl:text>
+			<fo:inline ><fo:external-graphic scaling="uniform" content-height="scale-to-fit" content-width="2mm" src="/opt/www/loop.oncampus.de/mediawiki/skins/loop/images/print/www_link.png"></fo:external-graphic></fo:inline>
+		</fo:basic-link>
+	</xsl:template>	
+
+	<xsl:template match="php_link_internal">
+		<fo:basic-link text-decoration="underline">
+			<xsl:attribute name="internal-destination"><xsl:value-of select="@href"></xsl:value-of></xsl:attribute>
+			<xsl:value-of select="."></xsl:value-of>
+		</fo:basic-link>
+	</xsl:template>		
+	
+	<xsl:template match="php_link_image">
+	
+		<xsl:variable name="align">
+			<xsl:choose>
+				<xsl:when test="ancestor::extension[@extension_name='loop_figure']">inside</xsl:when>			
+				<xsl:when test="@align='left'">start</xsl:when>
+				<xsl:when test="@align='right'">end</xsl:when>
+				<xsl:otherwise>none</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>	
+	
+	<fo:float>
+		<xsl:attribute name="float" value="$align"></xsl:attribute>				
+				<xsl:choose>
+				<xsl:when test="$align='start'">
+					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
+				</xsl:when>			
+				<xsl:when test="$align='end'">
+					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
+				</xsl:when>
+				<xsl:otherwise>
+					
+				</xsl:otherwise>
+			</xsl:choose>
+		
+		<fo:block font-size="0pt" line-height="0pt" padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt" padding-left="0pt" padding-right="0pt">
+			<fo:external-graphic scaling="uniform" content-height="scale-to-fit"  dominant-baseline="reset-size">
+				<!-- <xsl:choose>
+					<xsl:when test="$align='start'">
+						<xsl:attribute name="padding-right">7mm</xsl:attribute>				
+					</xsl:when>
+					<xsl:when test="$align='end'">
+						<xsl:attribute name="padding-right">7mm</xsl:attribute>				
+					</xsl:when>					
+					<xsl:otherwise>
+						<xsl:attribute name="padding-left">0mm</xsl:attribute>
+					</xsl:otherwise>
+				</xsl:choose> -->							
+				<xsl:attribute name="src" ><xsl:value-of select="@imagepath"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="content-width" ><xsl:value-of select="@imagewidth"></xsl:value-of></xsl:attribute>
+			</fo:external-graphic>
+		</fo:block>
+	</fo:float>		
+			
 		
 	</xsl:template>	
 	

--- a/xsl/pdf_params.xml
+++ b/xsl/pdf_params.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+	<pageheight>297mm</pageheight>
+	<pagewidth>210mm</pagewidth>
+
+	<hyphenate>true</hyphenate>
+
+	<font_family>Cambria, 'Cambria Math'</font_family>
+</config>

--- a/xsl/pdf_params.xsl
+++ b/xsl/pdf_params.xsl
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:functx="http://www.functx.com" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsl:param name="config_file">
+        <xsl:value-of select="'pdf_params.xml'"/>
+    </xsl:param>
+    
+    <xsl:param name="pageheight">
+		<xsl:value-of select="document($config_file)/config/pageheight"/>
+    </xsl:param>
+    
+    <xsl:param name="pagewidth">
+		<xsl:value-of select="document($config_file)/config/pagewidth"/>
+    </xsl:param>
+    
+    <xsl:param name="hyphenate">
+		<xsl:value-of select="document($config_file)/config/hyphenate"/>
+    </xsl:param>
+    
+    <xsl:param name="font_family">
+		<xsl:value-of select="document($config_file)/config/font_family"/>
+    </xsl:param>    
+    
+    
+</xsl:stylesheet>

--- a/xsl/pdf_terms.xml
+++ b/xsl/pdf_terms.xml
@@ -2,5 +2,6 @@
 <terms>
 	<msg name="word_state" lang="en">state</msg>
 	<msg name="word_state" lang="de">Stand</msg>
-	
+	<msg name="word_content" lang="en">Content</msg>
+	<msg name="word_content" lang="de">Inhalt</msg>	
 </terms>

--- a/xsl/pdf_terms.xml
+++ b/xsl/pdf_terms.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<terms>
+	<msg name="word_state" lang="en">state</msg>
+	<msg name="word_state" lang="de">Stand</msg>
+	
+</terms>

--- a/xsl/pdf_terms.xsl
+++ b/xsl/pdf_terms.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="http://exslt.org/functions" extension-element-prefixes="func" xmlns:functx="http://www.functx.com">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="http://exslt.org/functions" extension-element-prefixes="func" xmlns:functx="http://www.functx.com">
 
     <xsl:param name="terms_file">
         <xsl:value-of select="'pdf_terms.xml'"/>
@@ -11,5 +11,6 @@
 	</func:function>
 
 	<xsl:variable name="word_state"  select="functx:get_term_name('word_state')" />
+	<xsl:variable name="word_content"  select="functx:get_term_name('word_content')" />
 
 </xsl:stylesheet>

--- a/xsl/pdf_terms.xsl
+++ b/xsl/pdf_terms.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:func="http://exslt.org/functions" extension-element-prefixes="func" xmlns:functx="http://www.functx.com">
+
+    <xsl:param name="terms_file">
+        <xsl:value-of select="'pdf_terms.xml'"/>
+    </xsl:param>
+ 
+	<func:function name="functx:get_term_name">
+		<xsl:param name="term_name_key"/>
+		<func:result select="document($terms_file)/terms/msg[(@name=$term_name_key) and (@lang=$lang)]"/>
+	</func:function>
+
+	<xsl:variable name="word_state"  select="functx:get_term_name('word_state')" />
+
+</xsl:stylesheet>


### PR DESCRIPTION
# Basis für PDF Export und einige Fixes

## Beschreibung der Änderungen
Basis für den PDF Export.
Bisher wird nur die Coverpage erstellt.

## Test
Auf Spezialseite gehen und LOOP als PDF exportieren
https:// xxx .oncampus.de/loop/Spezial:LoopExport

Standardmäßig ist der PDF Export nur für angemeldete Benutzer erlaubt


