### PR TITLE
fixed escaping in xml for pdf export

### DIFF
--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -47,7 +47,8 @@ class LoopXml {
 		$xml .= "id=\"article" . $structureItem->getArticle() . "\" ";
 		$xml .= 'toclevel="'.$structureItem->getTocLevel().'" ';
 		$xml .= 'tocnumber="'.$structureItem->getTocNumber().'" ';
-		$xml .= 'toctext="'.htmlspecialchars($structureItem->getTocText()).'" ';		
+		#$xml .= 'toctext="'.htmlspecialchars($structureItem->getTocText()).'" ';		
+		$xml .= 'toctext="'.$structureItem->getTocText().'" ';
 		$xml .= ">\n";
 		$xml .= $wiki2xml->parse ( $content );
 		$xml .= "\n</article>\n";
@@ -65,7 +66,8 @@ class LoopXml {
 			$toc_xml .= 'id="article'.$child->getArticle().'" ';
 			$toc_xml .= 'toclevel="'.$child->getTocLevel().'" ';
 			$toc_xml .= 'tocnumber="'.$child->getTocNumber().'" ';
-			$toc_xml .= 'toctext="'.htmlspecialchars($child->getTocText()).'" ';
+			#$toc_xml .= 'toctext="'.htmlspecialchars($child->getTocText()).'" ';
+			$toc_xml .= 'toctext="'.$child->getTocText().'" ';
 			$toc_xml .= ">";
 				
 			if ($subchilds = $child->getDirectChildItems()) {

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -362,9 +362,23 @@
 		<xsl:attribute name="font-size">12.5pt</xsl:attribute>
 		<xsl:attribute name="font-weight">normal</xsl:attribute>
 		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
-	</xsl:template>	
-	<xsl:template name="font_subsubhead">
+	</xsl:template>
+	
+	
+	<xsl:template name="font_subsubsubsubhead">
 		<xsl:attribute name="font-size">11.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
+	</xsl:template>		
+	<xsl:template name="font_subsubsubhead">
+		<xsl:attribute name="font-size">11.5pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
+		<xsl:attribute name="margin-top">7pt</xsl:attribute>
+	</xsl:template>	
+		
+	<xsl:template name="font_subsubhead">
+		<xsl:attribute name="font-size">12.5pt</xsl:attribute>
 		<xsl:attribute name="font-weight">bold</xsl:attribute>
 		<xsl:attribute name="line-height">18.5pt</xsl:attribute>
 		<xsl:attribute name="margin-top">7pt</xsl:attribute>
@@ -389,10 +403,21 @@
 	</xsl:template>	
 	
 	<xsl:template match="paragraph">
-		<fo:block margin-top="7pt">
-			<xsl:call-template name="font_normal"></xsl:call-template>
-			<xsl:apply-templates></xsl:apply-templates>
-		</fo:block>
+		<xsl:choose>
+			<xsl:when test="preceding::*[1][name()='heading' and (@level='4' or @level='5')]">
+				<fo:block >
+					<xsl:call-template name="font_normal"></xsl:call-template>
+					<xsl:apply-templates></xsl:apply-templates>
+				</fo:block>	
+			</xsl:when>
+			<xsl:otherwise>
+	
+				<fo:block margin-top="7pt">
+					<xsl:call-template name="font_normal"></xsl:call-template>
+					<xsl:apply-templates></xsl:apply-templates>
+				</fo:block>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 	
 	<xsl:template match="preblock" >
@@ -526,8 +551,11 @@
 						<xsl:when test="$level='3'">
 							<xsl:call-template name="font_subsubhead"></xsl:call-template>
 						</xsl:when>
+						<xsl:when test="$level='4'">
+							<xsl:call-template name="font_subsubsubhead"></xsl:call-template>
+						</xsl:when>						
 						<xsl:otherwise>
-							<xsl:call-template name="font_subsubhead"></xsl:call-template>
+							<xsl:call-template name="font_subsubsubsubhead"></xsl:call-template>
 						</xsl:otherwise>
 					</xsl:choose>
 					<!-- <xsl:value-of select="."></xsl:value-of> -->


### PR DESCRIPTION
# Escaping Seitentitel

## Beschreibung der Änderungen
Escaping geändert 

##Test
Seitentitel mit & werden jetzt im PDF nicht mehr zu &amp;


