### PR TITLE
fixed edit mode not being changed on specialpages

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -12,12 +12,14 @@
 	"descriptionmsg": "loop-desc",
 	"licence-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.29.0",
+		"MediaWiki": ">= 1.31.0",
 		"extensions": {
 			"WikiEditor": "*"
 		}
 	},
 	"AutoloadClasses": {
+		"Loop": "includes/Loop.php",
+		"LoopHooks": "includes/Loop.hooks.php",
 		"LoopUpdater": "schema/LoopUpdater.php",
 		"LoopStructure": "includes/LoopStructure.php",
 		"LoopStructureItem": "includes/LoopStructure.php",
@@ -32,8 +34,7 @@
 		"LoopExportEpub": "includes/LoopExport.php",
 		"LoopExportHtml": "includes/LoopExport.php",
 		"LoopExportScorm": "includes/LoopExport.php",
-		"SpecialLoopExport": "includes/SpecialLoopExport.php",
-		"LoopHooks": "includes/Loop.hooks.php"
+		"SpecialLoopExport": "includes/SpecialLoopExport.php"
 	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates":[
@@ -41,6 +42,9 @@
 		],
 		"MediaWikiPerformAction":[
 			"LoopHooks::onMediaWikiPerformAction"
+		],
+		"SpecialPageBeforeExecute":[
+			"LoopHooks::onSpecialPageBeforeExecute"
 		]
 	},
 	"SpecialPages": {

--- a/extension.json
+++ b/extension.json
@@ -40,11 +40,8 @@
 		"LoadExtensionSchemaUpdates":[
 			"LoopUpdater::onLoadExtensionSchemaUpdates"
 		],
-		"MediaWikiPerformAction":[
-			"LoopHooks::onMediaWikiPerformAction"
-		],
-		"SpecialPageBeforeExecute":[
-			"LoopHooks::onSpecialPageBeforeExecute"
+		"BeforeInitialize":[
+			"LoopHooks::onBeforeInitialize"
 		]
 	},
 	"SpecialPages": {

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -15,32 +15,34 @@ class LoopHooks {
 	 */
 	public static function onMediaWikiPerformAction( $output, $article, $title, $user, $request, $wiki ) {
 		
-		// catch action loopeditmode and save setting in user options
-		if ( $user->isAllowed( 'edit' ) ) {
-			$loopeditmodeRequestValue  = $request->getText( 'loopeditmode' );
-			if( isset( $loopeditmodeRequestValue ) && ( in_array( $loopeditmodeRequestValue, array( '0', '1' ) ) ) ) {
-				$user->setOption( 'loopeditmode', $loopeditmodeRequestValue );
-				$user->saveSettings();
-			}
-		}	
-		
-		// catch action loopeditmode and save setting in user options
-		
-		if ( $user->isAllowed( 'loop-rendermode' ) ) {
-			$looprendermodeRequestValue  = $request->getText( 'looprendermode' );
-			if( isset( $looprendermodeRequestValue ) && ( in_array( $looprendermodeRequestValue, array( 'offline', 'epub' ) ) ) ) {
-				$user->setOption( 'looprendermode', $looprendermodeRequestValue );
-				$user->saveSettings();
-			} else {
-				$user->setOption( 'looprendermode', 'default' );
-				$user->saveSettings();
-			}
-		}		
+		Loop::handleLoopRequest( $output, $request, $user );
 		
 		return true;
 	}
 	/**
-	 * Cache different page version depending on status of LoopEditMode
+	 * Catch request to perform LoopEditMode on Special Pages
+	 * 
+	 * This is attached to the MediaWiki 'SpecialPageBeforeExecute' hook.
+	 * 
+	 * @param SpecialPage $special
+	 * @param string $subPage
+	 */
+	public static function onSpecialPageBeforeExecute( $special, $subPage ) { 
+	
+		global $wgRequest, $wgOut;
+		$output = $wgOut;
+		$user = $output->getUser();
+		$request = $wgRequest;
+	
+		Loop::handleLoopRequest( $output, $request, $user );
+		
+		return true;
+	
+	}
+	
+	
+	/**
+	 * Cache different page version depending on status of Mode
 	 *
 	 * This is attached to the MediaWiki 'PageRenderingHash' hook.
 	 *

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -2,44 +2,23 @@
 class LoopHooks {
 
 	/**
-	 * Catch the Request to perform custom action LoopEditMode
+	 * Catch the Request to perform custom action LoopEditMode and LoopRenderMode
 	 * 
-	 * This is attached to the MediaWiki 'MediaWikiPerformAction' hook.
+	 * This is attached to the MediaWiki 'onBeforeInitialize' hook.
 	 * 
-	 * @param OutputPage $output
-	 * @param Article $article
 	 * @param Title $title
+	 * @param Article $article
+	 * @param OutputPage $output
 	 * @param User $user
 	 * @param Request $request
 	 * @param Wiki $wiki
 	 */
-	public static function onMediaWikiPerformAction( $output, $article, $title, $user, $request, $wiki ) {
+	public static function onBeforeInitialize( $title, $article = null, $output, $user, $request, $wiki ) {
 		
 		Loop::handleLoopRequest( $output, $request, $user );
 		
 		return true;
 	}
-	/**
-	 * Catch request to perform LoopEditMode on Special Pages
-	 * 
-	 * This is attached to the MediaWiki 'SpecialPageBeforeExecute' hook.
-	 * 
-	 * @param SpecialPage $special
-	 * @param string $subPage
-	 */
-	public static function onSpecialPageBeforeExecute( $special, $subPage ) { 
-	
-		global $wgRequest, $wgOut;
-		$output = $wgOut;
-		$user = $output->getUser();
-		$request = $wgRequest;
-	
-		Loop::handleLoopRequest( $output, $request, $user );
-		
-		return true;
-	
-	}
-	
 	
 	/**
 	 * Cache different page version depending on status of Mode

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -1,0 +1,35 @@
+<?php class Loop {
+
+	/**
+	 * Save changes in LoopEditMode and LoopRenderMode
+	 * 
+	 * This is called by 'SpecialPageBeforeExecute' and 'MediaWikiPerformAction' hooks.
+	 * 
+	 * @param OutputPage $output
+	 * @param Request $request
+	 * @param User $user
+	 */
+	public static function handleLoopRequest( $output, $request, $user ) { 
+		
+		if ( $user->isAllowed( 'edit' ) ) {
+			$loopeditmodeRequestValue  = $request->getText( 'loopeditmode' );
+			if( isset( $loopeditmodeRequestValue ) && ( in_array( $loopeditmodeRequestValue, array( "0", "1" ) ) ) ) {
+				$user->setOption( 'loopeditmode', $loopeditmodeRequestValue );
+				$user->saveSettings();
+			}
+		}
+		
+		if ( $user->isAllowed( 'loop-rendermode' ) ) {
+			$looprendermodeRequestValue  = $request->getText( 'looprendermode' );
+			if( isset( $looprendermodeRequestValue ) && ( in_array( $looprendermodeRequestValue, array( 'offline', 'epub' ) ) ) ) {
+				$user->setOption( 'looprendermode', $looprendermodeRequestValue );
+				$user->saveSettings();
+			} else {
+				$user->setOption( 'looprendermode', 'default' );
+				$user->saveSettings();
+			}
+		}	
+			
+	}
+	
+}

--- a/includes/SpecialLoopStructure.php
+++ b/includes/SpecialLoopStructure.php
@@ -28,7 +28,7 @@ class SpecialLoopStructure extends SpecialPage {
 			. $this->msg( 'loopstructure-specialpage-title' )->parse()
 		);
 		
-		if( ! $user->isAnon() && $user->isAllowed( 'loop-toc-edit' ) && $loopRenderMode == 'default' && $loopEditMode == true ) {
+		if( ! $user->isAnon() && $user->isAllowed( 'loop-toc-edit' ) && $loopRenderMode == 'default' && $loopEditMode ) {
 			
 			# show link to the edit page if user is permitted
 			


### PR DESCRIPTION
Auf Spezialseiten wurden Änderungen des LoopEditModes nicht gespeichert, weil der verwendete Hook auf Spezialseiten nicht greift. Dazu wurde ein weiterer Hook eingefügt.

Auch den Skin updaten!
