### PR TITLE
forcetoc mode for edit structure specialpage

### DIFF
--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 use MediaWiki\MediaWikiServices;
 
@@ -8,34 +8,34 @@ use MediaWiki\MediaWikiServices;
  */
 
 class LoopStructure {
-	
+
 	private $id = 0; // id of the structure
 	private $properties = array(); // array of structure properties
 	private $propertiesLoaded = false; // bool properties loaded from database
 	public $mainPage; // article id of the main page
 	public $structureItems = array(); // array of structure items
 
-	
+
 	function __construct() {
 		$this->id = 0;
 	}
 
-	
+
 	public function getId() {
 		return $this->id;
 	}
-	
+
 	public function render() {
-		
+
 		$text = '';
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-		
+
 		foreach( $this->structureItems as $structureItem ) {
-			
+
 			if( intval( $structureItem->tocLevel ) === 0 ) {
-				
+
 				$text .= '<h2>'.$structureItem->tocText.'</h2>';
-				
+
 			} else {
 
 				if( isset( $structureItem->tocLevel ) && $structureItem->tocLevel > 0 ) {
@@ -43,27 +43,27 @@ class LoopStructure {
 				} else {
 					$tabLevel = 1;
 				}
-				
+
 				$link = $linkRenderer->makeLink(
 					Title::newFromID( $structureItem->article ),
 					new HtmlArmor( $structureItem->tocNumber .' '. $structureItem->tocText )
-				); 
-				
+				);
+
 				$text .= '<div class="loopstructure-level-'.$structureItem->tocLevel.'">' . str_repeat('	',  $tabLevel ) . $link . '</div>';
-			
+
 			}
-				
+
 		}
-		
+
 		return $text;
-		
+
 	}
-	
+
 	/**
 	 * Converts the structureitems to the table of contents as wikitext.
 	 */
 	public function renderAsWikiText() {
-		
+
 		$wikiText = '';
 
 		foreach( $this->structureItems as $structureItem ) {
@@ -73,13 +73,13 @@ class LoopStructure {
 			} else {
 				$wikiText .= str_repeat( '=', $structureItem->tocLevel ).' '.$structureItem->tocText.' '.str_repeat( '=', $structureItem->tocLevel ).PHP_EOL;
 			}
-			
+
 		}
-		
+
 		return $wikiText;
-		
+
 	}
-	
+
 	/**
 	 * Converts wikitext to LoopStructureItems.
 	 * @param $wikiText
@@ -115,9 +115,9 @@ class LoopStructure {
 		$parent_id[0] = $this->mainPage;
 		$max_level = 0;
 		$sequence = 0;
-		
+
 		unset( $this->structureItems );
-		
+
 		$loopStructureItem = new LoopStructureItem();
 		$loopStructureItem->structure = $this->id;
 		$loopStructureItem->article = $this->mainPage;
@@ -128,23 +128,23 @@ class LoopStructure {
 		$loopStructureItem->sequence = $sequence;
 		$loopStructureItem->tocNumber = '';
 		$loopStructureItem->tocText = $rootTitleText;
-		
+
 		$this->structureItems[$sequence] = $loopStructureItem;
 		$sequence++;
-	
+
 		$regex = "/(<li class=\"toclevel-)(\\d)( tocsection-)(.*)(<span class=\"tocnumber\">)([\\d\\.]+)(<\\/span> <span class=\"toctext\">)(.*)(<\\/span)/";
 		preg_match_all( $regex, $wikiText, $matches );
 
 		for( $i=0; $i < count( $matches[0] ); $i++ ) {
-	
+
 			$tocLevel = $matches[2][$i];
 			$tocNumber = $matches[6][$i];
 			$tocText = $matches[8][$i];
 			$tocArticleId = 0;
-		
+
 			$itemTitle = Title::newFromText($tocText);
 			$tocArticleId = $itemTitle->getArticleID();
-		
+
 			# create new page for item
 			if( $tocArticleId == 0 ) {
 				$newPage = WikiPage::factory( Title::newFromText( $tocText ) );
@@ -153,18 +153,18 @@ class LoopStructure {
 				$newTitle = $newPage->getTitle();
 				$tocArticleId = $newTitle->getArticleId();
 			}
-			
+
 			# get parent article
 			$parent_id[$tocLevel] = $tocArticleId;
-	
+
 			if($tocLevel > $max_level) {
 				$max_level = $tocLevel;
 			}
-	
+
 			for( $j = $tocLevel + 1; $j <= $max_level; $j++ ) {
 				$parent_id[$j] = 0;  # clear lower levels to prevent using an old value in case some intermediary levels are omitted
 			}
-	
+
 			$parentArticleId = $parent_id[$tocLevel - 1];
 			$parentArticleId = intval($parentArticleId);
 
@@ -172,7 +172,7 @@ class LoopStructure {
 			$previousItem = $this->structureItems[$sequence-1];
 			$previousArticleId = $previousItem->article;
 			$previousItem->nextArticle = $tocArticleId;
-			
+
 			$loopStructureItem = new LoopStructureItem();
 			$loopStructureItem->structure = $this->id;
 			$loopStructureItem->article = $tocArticleId;
@@ -183,30 +183,30 @@ class LoopStructure {
 			$loopStructureItem->sequence = $sequence;
 			$loopStructureItem->tocNumber = $tocNumber;
 			$loopStructureItem->tocText = $tocText;
-	
+
 			$this->structureItems[$sequence] = $loopStructureItem;
 			$sequence++;
-	
+
 		}
-	
+
 		return true;
-	
+
 	}
-	
+
 	public function getStructureItems() {
 		if (!$this->structureItems) {
 			$this->loadStructureItems();
 		}
 		return $this->structureItems;
 	}
-	
+
 	/**
 	 * Load items from database
 	 */
 	public function loadStructureItems() {
-	
+
 		$dbr = wfGetDB( DB_SLAVE );
-		
+
 		$res = $dbr->select(
 			'loop_structure_items',
 			array(
@@ -228,13 +228,13 @@ class LoopStructure {
 				'ORDER BY' => 'lsi_sequence ASC'
 			)
 		);
-		
+
 		foreach ( $res as $row ) {
-	
+
 			if ($row->lsi_toc_level == 0) {
 				$this->mainPage = $row->lsi_article;
 			}
-			
+
 			$loopStructureItem = new LoopStructureItem();
 			$loopStructureItem->id = $row->lsi_id;
 			$loopStructureItem->article = $row->lsi_article;
@@ -245,12 +245,12 @@ class LoopStructure {
 			$loopStructureItem->sequence = $row->lsi_sequence;
 			$loopStructureItem->tocNumber = $row->lsi_toc_number;
 			$loopStructureItem->tocText = $row->lsi_toc_text;
-	
+
 			$this->structureItems[] = $loopStructureItem;
-			
+
 		}
 	}
-	
+
 	/**
 	 * Save items to database
 	 */
@@ -259,28 +259,28 @@ class LoopStructure {
 			$structureItem->addToDatabase();
 		}
 	}
-	
+
 	/**
 	 * Delete all items from database
 	 */
 	public function deleteItems() {
-	
+
 		$dbw = wfGetDB( DB_MASTER );
 		$dbw->delete(
 			'loop_structure_items',
 			'*',
 			__METHOD__
 		);
-	
+
 		if( isset( $this->structureItems )) {
 			unset( $this->structureItems );
 		}
-		
+
 		return true;
 
 	}
-	
-	
+
+
 	public function lastChanged() {
 		$dbr = wfGetDB( DB_SLAVE );
 		$last_touched  =  $dbr->selectField(
@@ -300,11 +300,11 @@ class LoopStructure {
 		} else {
 			return false;
 		}
-	
-	
+
+
 	}
-	
-	
+
+
 	/**
 	 * Get the mainpage
 	 * @return Int
@@ -312,7 +312,7 @@ class LoopStructure {
 	function getMainpage() {
 		return $this->mainPage;
 	}
-	
+
 	/**
 	 * Get the structure title
 	 * @return string structure title
@@ -323,22 +323,22 @@ class LoopStructure {
 			$lsTitle = Title::newFromID($this->getMainpage())->getText();
 		}
 		return $lsTitle;
-	}	
-	
-	
-}	
+	}
+
+
+}
 
 /**
  *  Class representing a single page of a LoopStructure
  */
 class LoopStructureItem {
-	
+
 	public $id; // id of the structure item
 	public $structure = 0; // id of the corresponding structure
 	public $article; // article id of the page
 	public $previousArticle; // article id from the previous page
 	public $nextArticle; // article id from the next page
-	public $parentArticle; // article id from the parent page 
+	public $parentArticle; // article id from the parent page
 	public $tocLevel; // Level within the corresponding structure
 	public $sequence; // Sequential number within the corresponding structure
 	public $tocNumber; // string rrepresentation of the chapter number
@@ -349,12 +349,12 @@ class LoopStructureItem {
 	 * @return bool true
 	 */
 	function addToDatabase() {
-		
+
 		if ($this->article!=0) {
-			
+
 			$dbw = wfGetDB( DB_MASTER );
 			$this->id = $dbw->nextSequenceValue( 'LoopStructureItem_id_seq' );
-			
+
 			$dbw->insert(
 				'loop_structure_items',
 				array(
@@ -372,9 +372,9 @@ class LoopStructureItem {
 			);
 			$this->id = $dbw->insertId();
 		}
-		
+
 		return true;
-		
+
 	}
 
 	/**
@@ -384,7 +384,7 @@ class LoopStructureItem {
 	 * @param int $structure
 	 */
 	public static function newFromIds( $article ) {
-	
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$res = $dbr->select(
 			'loop_structure_items',
@@ -407,9 +407,9 @@ class LoopStructureItem {
 				'ORDER BY' => 'lsi_sequence ASC'
 			)
 		);
-	
+
 		if( $row = $res->fetchObject() ) {
-	
+
 			$loopStructureItem = new LoopStructureItem();
 			$loopStructureItem->id = $row->lsi_id;
 			$loopStructureItem->article = $row->lsi_article;
@@ -420,17 +420,17 @@ class LoopStructureItem {
 			$loopStructureItem->sequence = $row->lsi_sequence;
 			$loopStructureItem->tocNumber = $row->lsi_toc_number;
 			$loopStructureItem->tocText = $row->lsi_toc_text;
-				
+
 			return $loopStructureItem;
-				
+
 		} else {
-				
+
 			return false;
-				
+
 		}
-	
+
 	}
-	
+
 
 	/**
 	 * Get item for given article and structure from database
@@ -439,7 +439,7 @@ class LoopStructureItem {
 	 * @param int $structure
 	 */
 	public static function newFromToctext( $toctext ) {
-	
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$res = $dbr->select(
 				'loop_structure_items',
@@ -462,9 +462,9 @@ class LoopStructureItem {
 						'ORDER BY' => 'lsi_sequence ASC'
 				)
 		);
-	
+
 		if( $row = $res->fetchObject() ) {
-	
+
 			$loopStructureItem = new LoopStructureItem();
 			$loopStructureItem->id = $row->lsi_id;
 			$loopStructureItem->article = $row->lsi_article;
@@ -475,19 +475,19 @@ class LoopStructureItem {
 			$loopStructureItem->sequence = $row->lsi_sequence;
 			$loopStructureItem->tocNumber = $row->lsi_toc_number;
 			$loopStructureItem->tocText = $row->lsi_toc_text;
-	
+
 			return $loopStructureItem;
-	
+
 		} else {
-	
+
 			return false;
-	
+
 		}
-	
-	}	
-	
+
+	}
+
 	public function getPreviousChapterItem () {
-		
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$prev_id =  $dbr->selectField(
 			'loop_structure_items',
@@ -502,17 +502,17 @@ class LoopStructureItem {
 				'ORDER BY' => 'lsi_sequence DESC'
 			)
 		);
-		
+
 		if( ! empty( $prev_id )) {
 			return LoopStructureItem::newFromIds( $prev_id );
 		} else {
 			return false;
 		}
-		
+
 	}
-	
+
 	public function getNextChapterItem () {
-		
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$next_id = $dbr->selectField(
 			'loop_structure_items',
@@ -526,92 +526,92 @@ class LoopStructureItem {
 				'ORDER BY' => 'lsi_sequence ASC'
 			)
 		);
-		
+
 		if( ! empty( $next_id ) ) {
 			return LoopStructureItem::newFromIds( $next_id );
 		} else {
 			return false;
 		}
-		
+
 	}
-	
+
 	public function getPreviousItem () {
-		
+
 		if( isset( $this->previousArticle ) ) {
 			return LoopStructureItem::newFromIds( $this->previousArticle );
 		} else {
 			return false;
 		}
-		
+
 	}
-	
+
 	public function getNextItem () {
-		
+
 		if( isset( $this->nextArticle ) ) {
 			return LoopStructureItem::newFromIds( $this->nextArticle );
 		} else {
 			return false;
 		}
-		
+
 	}
-	
+
 	public function getParentItem () {
-		
+
 		if( isset( $this->parentArticle ) ) {
 			return LoopStructureItem::newFromIds( $this->parentArticle );
 		} else {
 			return false;
 		}
-		
+
 	}
-	
+
 	public function getBreadcrumb ( $max_len = 100 ) {
-		
+
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-	
+
 		$breadcrumb = '<li class="active">' . $this->tocNumber . ' ' . $this->tocText .'</li>';
 		$len = strlen( $this->tocNumber ) + strlen( $this->tocText ) + 1;
 		$level = $this->tocLevel;
-	
+
 		$items = array();
 		$item = $this->getParentItem();
 		$toc_number_len = 0;
-		
+
 		while( $item !== false ) {
 			$items[] = $item;
 			$toc_number_len = $toc_number_len + strlen ( $item->tocNumber ) + 1;
 			$item = $item->getParentItem();
 		}
-	
+
 		$max_text_len = $max_len - $len - $toc_number_len;
-		
-		if ( $level == 0 ) {	
+
+		if ( $level == 0 ) {
 			$level = 1;
 		}
-		
+
 		$max_item_text_len = floor( $max_text_len / $level );
-	
+
 		foreach( $items as $item ) {
-				
+
 			if( strlen( $item->tocText ) > $max_item_text_len ) {
 				$link_text = mb_substr( $item->tocText, 0, ( $max_item_text_len - 2 ) ) . '..';
 			} else {
 				$link_text = $item->tocText;
 			}
-			
+
 			$title = Title::newFromID( $item->article );
 			$link = $linkRenderer->makeLink( $title, new HtmlArmor( $item->tocNumber .' '. $link_text ) );
 			$breadcrumb = '<li>' . $link .'</li>' . $breadcrumb;
-			
+
 		}
-	
+
 		$breadcrumb = '<ol class="breadcrumb" id="breadcrumb">' . $breadcrumb . '</ol>';
 		return $breadcrumb;
-		
+
 	}
-	
+
 	public function lastChanged() {
-		
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$last_touched  =  $dbr->selectField(
 			array(
@@ -625,40 +625,40 @@ class LoopStructureItem {
 			),
 			__METHOD__
 		);
-		
+
 		if( ! empty( $last_touched )) {
 			return $last_touched;
 		} else {
 			return false;
 		}
-	
+
 	}
-	
+
 	public function getArticle () {
 		return $this->article;
 	}
-	
+
 	public function getId () {
 		return $this->id;
-	}	
+	}
 
 	public function getTocLevel () {
 		return $this->tocLevel;
 	}
-	
+
 	public function getTocText () {
 		return $this->tocText;
 	}
-	
+
 	public function getTocNumber () {
 		return $this->tocNumber;
-	}	
-	
-	
+	}
+
+
 	public function getDirectChildItems () {
-	
+
 		$childs = array();
-	
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$res = $dbr->select(
 				'loop_structure_items',
@@ -683,9 +683,9 @@ class LoopStructureItem {
 						'ORDER BY' => 'lsi_sequence ASC'
 				)
 				);
-	
+
 		while ($row = $res->fetchObject()) {
-	
+
 			$loopstructureItem = new LoopStructureItem();
 			$loopstructureItem->id = $row->lsi_id;
 			$loopstructureItem->structure = $row->lsi_structure;
@@ -697,11 +697,11 @@ class LoopStructureItem {
 			$loopstructureItem->sequence = $row->lsi_sequence;
 			$loopstructureItem->tocNumber = $row->lsi_toc_number;
 			$loopstructureItem->tocText = $row->lsi_toc_text;
-				
+
 			$childs[] = $loopstructureItem;
 		}
-	
+
 		return $childs;
 	}
-	
+
 }

--- a/includes/SpecialLoopStructure.php
+++ b/includes/SpecialLoopStructure.php
@@ -1,24 +1,24 @@
 <?php
 
 class SpecialLoopStructure extends SpecialPage {
-	
+
 	public function __construct() {
 		parent::__construct( 'LoopStructure' );
 	}
-	
+
 	public function execute( $sub ) {
-		
+
 		$user = $this->getUser();
 		$this->setHeaders();
 		$out = $this->getOutput();
 		$out->setPageTitle( $this->msg( 'loopstructure-specialpage-title' ) );
-		
+
 		$loopStructure = new LoopStructure();
 		$loopStructure->loadStructureItems();
-		
+
 		$loopEditMode = $this->getSkin()->getUser()->getOption( 'LoopEditMode', false, true );
 		$loopRenderMode = $this->getSkin()->getUser()->getOption( 'LoopRenderMode' );
-	
+
 		$out->addHtml(Html::openElement(
 				'h1',
 				array(
@@ -27,11 +27,11 @@ class SpecialLoopStructure extends SpecialPage {
 			)
 			. $this->msg( 'loopstructure-specialpage-title' )->parse()
 		);
-		
+
 		if( ! $user->isAnon() && $user->isAllowed( 'loop-toc-edit' ) && $loopRenderMode == 'default' && $loopEditMode ) {
-			
+
 			# show link to the edit page if user is permitted
-			
+
 			$out->addHtml(
 				Html::rawElement(
 					'a',
@@ -44,7 +44,7 @@ class SpecialLoopStructure extends SpecialPage {
 				)
 			);
 		}
-		
+
 		$out->addHtml(Html::closeElement(
 					'h1'
 				)
@@ -56,9 +56,9 @@ class SpecialLoopStructure extends SpecialPage {
 				$loopStructure->render()
 			)
 		);
-		
+
 	}
-	
+
 	/**
 	 * Specify the specialpages-group loop
 	 *
@@ -67,24 +67,24 @@ class SpecialLoopStructure extends SpecialPage {
 	protected function getGroupName() {
 		return 'loop';
 	}
-	
+
 }
 
 
 /**
  *  Special page representing the table of contents
  */
- 
+
 class SpecialLoopStructureEdit extends SpecialPage {
-	
+
 	public function __construct() {
 		parent::__construct( 'LoopStructureEdit' );
 	}
 
 	public function execute( $sub ) {
-		
+
 		global $wgSecretKey;
-		
+
 		$user = $this->getUser();
 		$this->setHeaders();
 		$out = $this->getOutput();
@@ -106,14 +106,14 @@ class SpecialLoopStructureEdit extends SpecialPage {
 		$loopStructure = new LoopStructure();
 		$loopStructure->loadStructureItems();
 		$currentStructureAsWikiText = $loopStructure->renderAsWikiText();
-		
+
         $request = $this->getRequest();
         $saltedToken = $user->getEditToken( $wgSecretKey, $request );
 		$newStructureContent = $request->getText( 'loopstructure-content' );
 		$requestToken = $request->getText( 't' );
 
 		$userIsPermitted = (! $user->isAnon() && $user->isAllowed( 'loop-toc-edit' ));
-		
+
 		$error = false;
 		$feedbackMessageClass = 'success';
 
@@ -122,6 +122,9 @@ class SpecialLoopStructureEdit extends SpecialPage {
 				if( $user->matchEditToken( $requestToken, $wgSecretKey, $request )) {
 
 					# the content was changend
+					# force toc rendering for tocs with three or fewer headings.
+					$newStructureContent = '__FORCETOC__' . PHP_EOL . $newStructureContent;
+
 					# use local parser to get a default parsed result
 					$localParser = new Parser();
 					$tmpTitle = Title::newFromText( 'NO TITLE' );
@@ -169,17 +172,17 @@ class SpecialLoopStructureEdit extends SpecialPage {
                                 $error = $this->msg( 'loopstructure-save-parse-error' )->parse();
                                 $feedbackMessageClass = 'danger';
                             }
-								
+
 						} else {
 							$error = $this->msg( 'loopstructure-save-parsed-structure-error' )->parse();
                             $feedbackMessageClass = 'danger';
 						}
-					
+
 					} else {
 						$error = $this->msg( 'loopstructure-save-parse-error' )->parse();
                         $feedbackMessageClass = 'danger';
 					}
-					
+
 				} else {
 					$error = $this->msg( 'loop-token-error' )->parse();
                     $feedbackMessageClass = 'danger';
@@ -189,7 +192,7 @@ class SpecialLoopStructureEdit extends SpecialPage {
 				$error = $this->msg( 'loop-permission-error' )->parse();
                 $feedbackMessageClass = 'danger';
 			}
-			
+
 		}
 
         # error message output (if exists)
@@ -205,11 +208,11 @@ class SpecialLoopStructureEdit extends SpecialPage {
                 )
             );
         }
-        
+
         if( $userIsPermitted ) {
-        	
+
         	# user is permitted to edit the toc, print edit form here
-        	
+
 	        $out->addHTML(
 	            Html::openElement(
 	                'form',
@@ -252,11 +255,11 @@ class SpecialLoopStructureEdit extends SpecialPage {
 	                'form'
 	            )
 	        );
-	        
+
         } else {
 
         	# user has no permission, just show content without textarea
-        	
+
         	$out->addHtml(
         		Html::rawElement(
         			'div',


### PR DESCRIPTION
# Beitrag zur LOOP Extension

## Beschreibung der Änderungen
Die Änderungen beheben den Bug, dass Mediawiki das Inhaltsverzeichnis nur aktualisiert, wenn es eine Mindestanzahl von Ebenen gibt (__FORCETOC__ mode). Außerdem wurden durch die Verwendung von Visual Code falsche Einrückungen korrigiert. 

##Test
Beschreibe wie ein Reviewer überprüfen kann, dass die Änderungen korrekt funktionieren.
Inhaltsverzeichnis mit 3 oder weniger Einträgen abspeichern.

