### PR TITLE
Logbucheinträge für Loop Exporte

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -93,6 +93,7 @@
 			"loop-export-html": false,
 			"loop-export-scorm": false,
 			"loop-pageaudio": false,
+			"loop-view-export-log": false,
 			"createtalk": false,
 			"createpage": false,
 			"writeapi": false

--- a/extension.json
+++ b/extension.json
@@ -119,6 +119,7 @@
 			"loop-export-scorm": true,
 			"loop-pageaudio": true,
 			"loop-settings-edit": true,
+			"loop-view-export-log": true,
 			"createpage": true,
 			"loop-rendermode": true,
 			"purgecache": true,
@@ -136,6 +137,7 @@
 			"loop-export-scorm": true,
 			"loop-pageaudio": true,
 			"loop-settings-edit": true,
+			"loop-view-export-log": true,
 			"unreviewedpages": true,
 			"upload": true,
 			"autoreview": true,
@@ -166,6 +168,7 @@
 			"loop-export-scorm": true,
 			"loop-pageaudio": true,
 			"loop-settings-edit": true,
+			"loop-view-export-log": true,
 			"unreviewedpages": true,
 			"upload": true,
 			"autoreview": true,
@@ -327,7 +330,8 @@
 		"loop-export-html",
 		"loop-export-scorm",
 		"loop-rendermode",
-		"loop-settings-edit"
+		"loop-settings-edit",
+		"loop-view-export-log"
 	],
 	"MessagesDirs": {
 		"Loop": [
@@ -488,5 +492,15 @@
 		}
 
 	},
+	"LogTypes": [ "loopexport" ],
+    "LogNames": {
+        "loopexport": "log-name-loopexport"
+    },
+    "LogHeaders": {
+        "loopexport": "log-name-loopexport"
+    },
+    "LogActionsHandlers": {
+        "loopexport/*": "LogFormatter"
+    },
 	"manifest_version": 2
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -97,5 +97,16 @@
 	"purgecache-purged": "Der Cache wurde gelöscht.",
 	"purgecache-button": "Löschen",
 	"right-purgecache": "OBJECTCACHE-Tabelle löschen",
-	"purgecache-no-permission": "Sie haben nicht die Berechtigung, den Inhalt dieser Seite zu sehen."
+	"purgecache-no-permission": "Sie haben nicht die Berechtigung, den Inhalt dieser Seite zu sehen.",
+	
+	"log-export-generated": "neu generiert",
+	"log-export-reused": "wiederverwendet",
+	"log-name-loopexport": "LOOP-Export Logs",
+	"log-description-loopexport": "Log-Einträge für jeden LOOP-Export",
+	"logentry-loopexport-pdf": "PDF wurde exportiert ($4)",
+	"logentry-loopexport-xml": "XML wurde exportiert ($4)",
+	"logentry-loopexport-mp3": "Hörbuch wurde exportiert ($4)",
+	"logentry-loopexport-html": "Offlineversion wurde exportiert",
+	"logentry-loopexport-epub": "ePub wurde exportiert ($4)",
+	"logentry-loopexport-pageaudio": "$3 wurde angehört ($4)"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -96,6 +96,16 @@
 	"purgecache-purged": "The cache has been purged.",
 	"purgecache-button": "Purge",
 	"right-purgecache": "Wipe the OBJECTCACHE table",
-	"purgecache-no-permission": "You do not have permission to view this page."
+	"purgecache-no-permission": "You do not have permission to view this page.",
 
+	"log-export-generated": "generated",
+	"log-export-reused": "reused",
+	"log-name-loopexport": "LOOP-Export logs",
+	"log-description-loopexport": "Log-entries for each LOOP export",
+	"logentry-loopexport-pdf": "PDF has been exported ($4)",
+	"logentry-loopexport-xml": "XML has been exported ($4)",
+	"logentry-loopexport-mp3": "Audiobook has been exported ($4)",
+	"logentry-loopexport-html": "Offline version has been exported",
+	"logentry-loopexport-epub": "ePub has been exported ($4)",
+	"logentry-loopexport-pageaudio": "$3 was listened to ($4)"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -95,5 +95,16 @@
 	"purgecache-warning": "Warning before execution of PurgeCache",
 	"purgecache-purged": "Message after purging",
 	"purgecache-button": "Button label for purging",
-	"right-purgecache": "Right for PurgeCache"
+	"right-purgecache": "Right for PurgeCache",
+	
+	"log-export-generated": "Log entry message for export files that have been generated at request",
+	"log-export-reused": "Log entry message for export files that have been reused",
+	"log-name-loopexport": "Name for logs of LOOP-Exports",
+	"log-description-loopexport": "Description for LOOP-Export logs",
+	"logentry-loopexport-pdf": "Log message for PDF export ($4 is used for generated/reused state)",
+	"logentry-loopexport-xml": "Log message for XML export ($4 is used for generated/reused state)",
+	"logentry-loopexport-mp3": "Log message for MP3 export ($4 is used for generated/reused state)",
+	"logentry-loopexport-html": "Log message for HTML export",
+	"logentry-loopexport-epub": "Log message for EPUB ($4 is used for generated/reused state)",
+	"logentry-loopexport-pageaudio": "Log message for page audio export ($4 is used for generated/reused state)"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -92,6 +92,16 @@
 	"purgecache-purged": "Cachen har rensats.",
 	"purgecache-button": "Rensa",
 	"right-purgecache": "Rensa OBJECTCACHE-tabellen",
-	"purgecache-no-permission": "Du har inte behörighet för att visa den här sidan."
+	"purgecache-no-permission": "Du har inte behörighet för att visa den här sidan.",
 
+	"log-export-generated": "genererats",
+	"log-export-reused": "återanvänts",
+	"log-name-loopexport": "LOOP-Export loggningar",
+	"log-description-loopexport": "Loggning för LOOP-Export",
+	"logentry-loopexport-pdf": "PDF har exporterats ($4)",
+	"logentry-loopexport-xml": "XML har exporterats ($4)",
+	"logentry-loopexport-mp3": "Ljudbok har exporterats ($4)",
+	"logentry-loopexport-html": "Offline version har exporterats",
+	"logentry-loopexport-epub": "ePub har exporterats ($4)",
+	"logentry-loopexport-pageaudio": "$3 lyssnades på ($4)"
 }

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -31,7 +31,8 @@ class LoopHooks {
 
 		global $wgRightsText, $wgRightsUrl, $wgRightsIcon, $wgLanguageCode, $wgDefaultUserOptions, $wgImprintLink, $wgPrivacyLink, 
 		$wgWhitelistRead, $wgFlaggedRevsExceptions, $wgFlaggedRevsLowProfile, $wgFlaggedRevsTags, $wgFlaggedRevsTagsRestrictions, 
-		$wgFlaggedRevsAutopromote, $wgShowRevisionBlock, $wgSimpleFlaggedRevsUI, $wgFlaggedRevsAutoReview;
+		$wgFlaggedRevsAutopromote, $wgShowRevisionBlock, $wgSimpleFlaggedRevsUI, $wgFlaggedRevsAutoReview, $wgLogRestrictions,
+		$wgFileExtensions;
 
 		$dbr = wfGetDB( DB_REPLICA );
 		# Check if table exists. SetupAfterCache hook fails if there is no loop_settings table.
@@ -85,6 +86,15 @@ class LoopHooks {
 		$wgShowRevisionBlock = false;
 		$wgSimpleFlaggedRevsUI = false;
 		$wgFlaggedRevsAutoReview = FR_AUTOREVIEW_CREATION_AND_CHANGES;
+
+		# Log viewing rights
+		$wgLogRestrictions["loopexport"] = "loop-view-export-log";
+		$wgLogRestrictions["block"] = "loop-view-export-log"; #Benutzersperr-Logbuch
+		$wgLogRestrictions["newusers"] = "loop-view-export-log"; #Neu angemeldete User-Logbuch
+		$wgLogRestrictions["rights"] = "loop-view-export-log"; #Benutzerrechte-Logbuch
+
+		# Uploadable file extensions
+		$wgFileExtensions = array_merge( $wgFileExtensions, array('pdf','ppt','pptx','xls','xlsx','doc','docx','odt','odc','odp','odg','zip','svg','eps','csv','psd','mp4','mp3','mpp','ter','ham','cdf','swr','xdr'));
 
 		return true;
 	}

--- a/includes/LoopMp3.php
+++ b/includes/LoopMp3.php
@@ -137,16 +137,35 @@ class LoopMp3 {
 			
 			$tagwriter->tag_data = $tagData;
 			$tagwriter->WriteTags();
+			
+			LoopMp3::writeLog( wfMessage("log-export-generated")->text(), $articleId );
 
 			return $filePathName;
 			
 		} elseif ( $fileUpToDate ) {
+			LoopMp3::writeLog( wfMessage("log-export-reused")->text(), $articleId );
 			return $filePathName;
 		} else {
 			return false;
 		}
 	}
+	/**
+	 * Adds a log entry for page audio export.
+	 *
+	 * @param string $msg
+	 * @param string $articleId
+	 */
+	private static function writeLog( $msg, $articleId ) {
+		
+		$logEntry = new ManualLogEntry( 'loopexport', 'pageaudio');
+		$logEntry->setTarget( Title::newFromId($articleId) );
+		$logEntry->setPerformer( User::newFromId(0) ); 
+		$logEntry->setParameters( [ '4::paramname' => $msg ] );
+		$logid = $logEntry->insert();
 
+		return true;
+
+	}
 	/**
 	 * Checks if a given existing file is up to date compared with given lastChanged date
 	 *

--- a/includes/SpecialLoopExport.php
+++ b/includes/SpecialLoopExport.php
@@ -37,47 +37,65 @@ class SpecialLoopExport extends SpecialPage {
 			case 'xml':
 				if ($user->isAllowed( 'loop-export-xml' )) {
 					$export = new LoopExportXml($structure, $request);
+					$logEntry = new ManualLogEntry( 'loopexport', "xml");
 				}
 				break;
 			case 'pdf':
 				if ($user->isAllowed( 'loop-export-pdf' )) {
 					$export = new LoopExportPdf($structure);
+					$logEntry = new ManualLogEntry( 'loopexport', "pdf");
 				}
 				break;
 			case 'mp3':
 				if ($user->isAllowed( 'loop-export-mp3' )) {
 					$export = new LoopExportMp3($structure);
+					$logEntry = new ManualLogEntry( 'loopexport', "mp3");
 				}
 				break;
 			case 'html':
 				if ($user->isAllowed( 'loop-export-html' )) {
 					$export = new LoopExportHtml($structure, $context);
+					$logEntry = new ManualLogEntry( 'loopexport', "html");
 				}
 			break;
 			case 'epub':
 				if ($user->isAllowed( 'loop-export-epub' )) {
 					$export = new LoopExportEpub($structure);
+					$logEntry = new ManualLogEntry( 'loopexport', "epub");
 				}
 			break;
 			case 'pageaudio':
 				if ($user->isAllowed( 'loop-pageaudio' )) {
 					$export = new LoopExportPageMp3($structure, $request);
+					# page audio logging is moved to LoopMp3.php
 				}
 				break;
 		}
 		
 		if ( $export != false ) {
+			$logMsg = "";
 
 			if ( $export->getExistingExportFile() && $export->fileExtension != "mp3" ) {
 					$export->getExistingExportFile();
+					$logMsg = wfMessage("log-export-reused")->text();
+					
 			} else {
 				$export->generateExportContent();
-					
+				
 				if ( $export->exportDirectory != "/export/html" && $export->fileExtension != "mp3" ) { # don't cache html exports
 					$export->saveExportFile();
-				}
+					$logMsg = wfMessage("log-export-generated")->text();
+				} 
 			}
 			if ($export->getExportContent() != null ) {
+				
+				if ( isset($logEntry) ) {
+					$logEntry->setTarget( Title::newFromId(1) );
+					$logEntry->setPerformer( User::newFromId(0) ); 
+					$logEntry->setParameters( [ '4::paramname' => $logMsg ] );
+					$logid = $logEntry->insert();
+				}
+
 				$this->getOutput()->disable();
 				wfResetOutputBuffers();
 				$export->sendExportHeader();


### PR DESCRIPTION
Admins, Autoren und Teacher_approve fürden sich unter Spezial:Logbuch (Loop-Exporte filtern) Logs zu Loop-Exporten ansehen. Die sehen so aus:
- Hauptseite wurde angehört (wiederverwendet)
- PDF/XML/ePub wurde exportiert (neu generiert)
- Offlineversion wurde exportiert

Bis auf die Offlineversion, die nicht zwischengespeichert wird, enthalten alle Logeinträge eine Information darüber, ob die Datei neu generiert wurde, oder die zwischengespeicherten Dateien benutzt wurden.