### PR TITLE
Referenzen 

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -57,7 +57,8 @@
 		"LoopTable": "includes/LoopTable.php",
 		"SpecialLoopTables": "includes/LoopTable.php",
 		"LoopTask": "includes/LoopTask.php",
-		"SpecialLoopTasks": "includes/LoopTask.php"
+		"SpecialLoopTasks": "includes/LoopTask.php",
+		"LoopReference": "includes/LoopReference.php"
 	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates":[
@@ -70,7 +71,8 @@
 			"LoopHooks::onPageRenderingHash"
 		],
 		"ParserFirstCallInit": [
-			"LoopObject::onParserSetup"
+			"LoopObject::onParserSetup",
+			"LoopReference::onParserSetup"
 		],
 		"PageContentSaveComplete": [
 			"LoopObject::onPageContentSaveComplete"
@@ -80,6 +82,9 @@
 		],
 		"SpecialPage_initList": [
 			"LoopHooks::onSpecialPageinitList"
+		],
+		"HtmlPageLinkRendererEnd": [
+			"LoopHooks::onHtmlPageLinkRendererEnd"
 		]
 	},
 	"SpecialPages": {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -145,6 +145,9 @@
 	"loopobject-error-unknown-alignmentoption" : "Die Auszeichnung besitzt für den Parameter Ausrichtung (align) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-unknown-indexoption" : "Die Auszeichnung besitzt für den Parameter Indexierung (index) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-unknown-showcopyrightoption" : "Die Auszeichnung besitzt für den Parameter Copyright anzeigen (show_copyright) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
-	"loopmedia-error-unknown-mediatype" : "Das Medienelement besitzt für den Parameter Medientyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Medienelementen: XXX"
+	"loopmedia-error-unknown-mediatype" : "Das Medienelement besitzt für den Parameter Medientyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Medienelementen: XXX",
+	"loopreference-error-unknown-titleoption" : "Die Referenz besitzt für den Parameter Titelanzeige (title) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Referenzen: XXX",
+	"loopreference-error-unknown-refid" : "Die Referenz bezieht sich auf eine unbekannte ID: '''$1'''.\nDokumentation zu Referenzen: XXX",
+	"loopreference-error-no-refid" : "Die Referenz besitzt keinen ID-Parameter (id).\nDokumentation zu Referenzen: XXX"
 	
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -143,7 +143,9 @@
 	"loopobject-error-unknown-alignmentoption" : "The object's alignment option (align) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopobject-error-unknown-indexingoption" : "The object's indexing option (index) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
 	"loopobject-error-unknown-showcopyrightoption" : "The object's show copyright option (show_copyright) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
-	"loopmedia-error-unknown-mediatype" : "The media's type option (type) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''."
-
-
+	"loopmedia-error-unknown-mediatype" : "The media's type option (type) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
+	"loopreference-error-unknown-titleoption" : "The reference's show title option (title) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
+	"loopreference-error-unknown-refid" : "The reference's given ID is unknown: '''$1'''.",
+	"loopreference-error-no-refid" : "The reference is missing a ID parameter (id)."
+	
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -142,6 +142,10 @@
 	"loopobject-error-unknown-alignmentoption" : "Error Message rendered when align option is unknown\n\nParameters:\n* $1 - align option\n* $2 supported align options",
 	"loopobject-error-unknown-indexingoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - indexing option\n* $2 supported index options",
 	"loopobject-error-unknown-showcopyrightoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - show_copyright option\n* $2 supported show_copyright options",
-	"loopmedia-error-unknown-mediatype" : "Error Message rendered when type option is unknown\n\nParameters:\n* $1 - type option\n* $2 supported type options"
+	"loopmedia-error-unknown-mediatype" : "Error Message rendered when type option is unknown\n\nParameters:\n* $1 - type option\n* $2 supported type options",
+	"loopreference-error-unknown-titleoption" : "Error Message rendered when title option is unknown\n\nParameters:\n* $1 - title option\n* $2 supported title options",
+	"loopreference-error-unknown-refid" : "Error Message rendered when id option is unknown.\n\nParameters:\n* $1 - given id",
+	"loopreference-error-no-refid" : "Error Message rendered when no id is given"
+	
 	
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -139,7 +139,11 @@
 	"loopobject-error-unknown-alignmentoption" : "Värdet av parametern (align) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-unknown-indexingoption" : "Värdet av parametern (index) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-unknown-showcopyrightoption" : "Värdet av parametern (show_copyright) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"loopmedia-error-unknown-mediatype" : "Värdet av parametern (type) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''."
+	"loopmedia-error-unknown-mediatype" : "Värdet av parametern (type) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
+	"loopreference-error-unknown-titleoption" : "Värdet av parametern (title) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
+	"loopreference-error-unknown-refid" : "Referensens angivit ID är okänd: '''$1'''.",
+	"loopreference-error-no-refid" : "Inget ID (id) har angivits i referensen."
+	
 	
 	
 }

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -83,4 +83,12 @@ class LoopHooks {
 		return true;
 	}
 
+	public static function onHtmlPageLinkRendererEnd( $linkRenderer, $target, $isKnown, &$text, &$attribs, &$ret ) {
+
+		# Add id to loop_reference links
+		if ( isset( $attribs["data-target"])) {
+			$attribs["href"] .= "#". $attribs["data-target"];
+		}
+		return true;
+	}
 }

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -71,15 +71,15 @@
 			$row = $res->fetchObject();
 
 			if ( isset( $row->lset_id ) ) {
-				$wgRightsText = ( empty( $row->lset_rightstext ) ? $wgRightsText : $row->lset_rightstext );
-				$wgRightsUrl = ( empty( $row->lset_rightsurl ) ? $wgRightsUrl : $row->lset_rightsurl );
-				$wgRightsIcon = ( empty( $row->lset_rightsicon ) ? $wgRightsIcon : $row->lset_rightsicon  );
-				$wgLanguageCode = ( empty( $row->lset_languagecode ) ? $wgLanguageCode : $row->lset_languagecode );
-				$wgDefaultUserOptions['LoopSkinStyle'] = ( empty( $row->lset_skinstyle ) ? 'loop-common' : $row->lset_skinstyle );
-				$wgWhitelistRead[] = empty( $row->lset_imprintlink ) ? $wgImprintLink : $row->lset_imprintlink;
-				$wgWhitelistRead[] = empty( $row->lset_privacylink ) ? $wgPrivacyLink : $row->lset_privacylink;
-				$wgLoopObjectNumbering = ( empty( $row->lset_numberingobjects ) ? $wgLoopObjectNumbering : $row->lset_numberingobjects );
-				$wgLoopNumberingType = ( empty( $row->lset_numberingtype ) ? $wgLoopNumberingType : $row->lset_numberingtype );
+				$wgRightsText = ( !isset( $row->lset_rightstext ) ? $wgRightsText : $row->lset_rightstext );
+				$wgRightsUrl = ( !isset( $row->lset_rightsurl ) ? $wgRightsUrl : $row->lset_rightsurl );
+				$wgRightsIcon = ( !isset( $row->lset_rightsicon ) ? $wgRightsIcon : $row->lset_rightsicon  );
+				$wgLanguageCode = ( !isset( $row->lset_languagecode ) ? $wgLanguageCode : $row->lset_languagecode );
+				$wgDefaultUserOptions['LoopSkinStyle'] = ( !isset( $row->lset_skinstyle ) ? 'loop-common' : $row->lset_skinstyle );
+				$wgWhitelistRead[] = !isset( $row->lset_imprintlink ) ? $wgImprintLink : $row->lset_imprintlink;
+				$wgWhitelistRead[] = !isset( $row->lset_privacylink ) ? $wgPrivacyLink : $row->lset_privacylink;
+				$wgLoopObjectNumbering = ( !isset( $row->lset_numberingobjects ) ? $wgLoopObjectNumbering : $row->lset_numberingobjects );
+				$wgLoopNumberingType = ( !isset( $row->lset_numberingtype ) ? $wgLoopNumberingType : $row->lset_numberingtype );
 				
 			}
 		}

--- a/includes/LoopFigure.php
+++ b/includes/LoopFigure.php
@@ -137,11 +137,9 @@ class LoopFigure extends LoopObject{
 	 * @return string
 	 */
 	public function renderForSpecialpage() {
-		global $wgLoopObjectNumbering, $wgLoopNumberingType;
+		global $wgLoopObjectNumbering;
 
 		$html = '<tr scope="row" class="ml-1 pb-3">';
-		#$html .= '<span class="ic ic-'.$this->getIcon().'"></span> ';
-	#	$html .= '<td scope="col" class=""><span class="font-weight-bold">'. wfMessage ( $this->getTag().'-name-short' )->inContentLanguage ()->text () . $numberText . ': ' . '</span></td>';
 		$html .= '<td scope="col" class="pl-0 pr-0">';
 		
 		if ( $this->mFile ) {
@@ -165,31 +163,9 @@ class LoopFigure extends LoopObject{
 			
 			$previousObjects = LoopObjectIndex::getObjectNumberingsForPage ( $lsi, $loopStructure );
 			if ( $lsi ) {
-					
-				$number = $previousObjects['loop_figure'] + $this->getNumber();
-			
-				if ( $wgLoopNumberingType == 'chapter' ) {
-			
-					$tocChapter = '';
-					preg_match('/(\d+)\.{0,1}/', $lsi->tocNumber, $tocChapterArray);
-
-					if (isset($tocChapterArray[1])) {
-						$tocChapter = $tocChapterArray[1];
-					} else {
-						$tocChapter = 0;
-					}
-					
-					
-					$numberText = ' ' . $tocChapter . '.' . $number;
-
-				} elseif ( $wgLoopNumberingType == 'ongoing' ) {
-					$numberText = ' ' . $number;
-				}
+				$numberText = " " . LoopObject::getObjectNumberingOutput($this->mId, $lsi, $loopStructure, $previousObjects);
 			}
 		}
-		#$html .= '<div class="col-10 pl-0">';
-		#$html .= '<div class="loop_object_footer ml-1">';
-		#$html .= '<span class="ic ic-'.$this->getIcon().'"></span> ';
 		$outputTitle = '';
 
 		if ( $this->getTitleFullyParsed() ) {

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -925,7 +925,7 @@ class LoopObject {
 		$cond = "";
 		// if a title is given, each page after given one is updated
 		if ( isset($title) ) {
-			$cond = "lsi_article=" . $title->getArticleID();
+			# $cond = "lsi_article=" . $title->getArticleID(); # TODO remove? Für referenzen müssen alle Seiten immer neu geladen werden.
 		} 
 
 		$dbr = wfGetDB ( DB_SLAVE );

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -255,28 +255,19 @@ class LoopObject {
 		#dd($numbering, $type);
 		$numberText = '';
 		if ( $wgLoopObjectNumbering == true ) {
-			if ( $wgLoopNumberingType == 'chapter' ) {
 		
-				$lsi = LoopStructureItem::newFromIds ( $this->mArticleId );
-				preg_match('/(\d+)\.{0,1}/', $lsi->tocNumber, $tocChapter);
-				if (isset($tocChapter[1])) {
-					$tocChapter = $tocChapter[1];
-				} else {
-					$tocChapter = 0;
-				}
+			$lsi = LoopStructureItem::newFromIds ( $this->mArticleId );
+				
+			if ( $lsi ) {
+					
+				$loopStructure = new LoopStructure();
+				$loopStructure->loadStructureItems();
+				$previousObjects = LoopObjectIndex::getObjectNumberingsForPage ( $lsi, $loopStructure );
 				
 				if ( $lsi ) {
-					
-					$loopStructure = new LoopStructure();
-					$loopStructure->loadStructureItems();
-					
-					$previousObjects = LoopObjectIndex::getObjectNumberingsForPage ( $lsi, $loopStructure );
-					#dd($previousObjects[$type]+$this->getNumber() );
-					$number = $previousObjects[$type] + $this->getNumber();
-					$numberText = ' ' . $tocChapter . '.' . $number;
+					$numberText = " " . LoopObject::getObjectNumberingOutput($this->mId, $lsi, $loopStructure, $previousObjects);
 				}
-			} else {
-				$numberText = ' ' . $this->getNumber();
+					
 			}
 		}
 		$outputTitle = '';
@@ -987,7 +978,7 @@ class LoopObject {
 	
 	public static function onParserAfterTidy(&$parser, &$text) {
 		
-		global $wgLoopNumberingType, $wgLoopObjectNumbering;
+		global $wgLoopObjectNumbering;
 		$title = $parser->getTitle();
 		$article = $title->getArticleID();
 		
@@ -1002,7 +993,7 @@ class LoopObject {
 			$loopStructure = new LoopStructure();
 			$loopStructure->loadStructureItems();
 			$previousObjects = LoopObjectIndex::getObjectNumberingsForPage ( $lsi, $loopStructure );
-			$allObjects = LoopObjectIndex::getAllObjects( $loopStructure );
+			#$allObjects = LoopObjectIndex::getAllObjects( $loopStructure );
 			
 		}
 		foreach ( self::$mObjectTypes as $objectType ) {
@@ -1011,42 +1002,16 @@ class LoopObject {
 			preg_match_all( "/(" . LOOPOBJECTNUMBER_MARKER_PREFIX . $objectType . ")(.*)(" . LOOPOBJECTNUMBER_MARKER_SUFFIX . ")/", $text, $matches );
 			
 			if ( $lsi && $wgLoopObjectNumbering == 1 ) {
-				if ( $wgLoopNumberingType == "chapter" ) {
-					$i = 0;
-					if ( isset( $matches[2][$i]) ) {
-						
-						#dd($objectid);
-						preg_match('/(\d+)\.{0,1}/', $lsi->tocNumber, $tocChapter);
-						if (isset($tocChapter[1])) {
-							$tocChapter = $tocChapter[1];
-						}
-						
-						foreach ( $matches[0] as $objectmarker ) {
-							$objectid = $matches[2][$i];
-							$number = '';
-							if ( isset( $allObjects[$objectid] ) ) {
-								$number = $previousObjects[$objectType] + $allObjects[$objectid]["nthoftype"];
-							}
-							if ( empty( $tocChapter ) ) {
-								$tocChapter = 0;
-							}
-							$text = preg_replace ( "/" . $objectmarker . "/", $tocChapter . "." . $number, $text );
+				
+				$i = 0;
+				foreach ( $matches[0] as $objectmarker ) {
+					$objectid = $matches[2][$i];
+					$numbering = self::getObjectNumberingOutput($objectid, $lsi, $loopStructure, $previousObjects);
+					
+					$text = preg_replace ( "/" . $objectmarker . "/", $numbering, $text );
+					$i++;
+				} 
 
-							$i++;
-						} 
-					}
-				} else {
-					$i = 0;
-					foreach ( $matches[0] as $objectmarker ) {
-						$objectid = $matches[2][$i];
-						$number = '';
-						if ( isset( $allObjects[$objectid] ) ) {
-							$number = $previousObjects[$objectType] + $allObjects[$objectid]["nthoftype"];
-						}
-						$text = preg_replace ( "/" . $objectmarker . "/", $number, $text );
-						$i++;
-					}
-				}
 			} else {
 				foreach ( $matches[0] as $objectmarker ) {
 					$text = preg_replace ( "/" . $objectmarker . "/", "", $text );
@@ -1055,6 +1020,37 @@ class LoopObject {
 		}
 		
 		return true;
+	}
+
+	public static function getObjectNumberingOutput($objectid, $lsi, $loopStructure, $previousObjects = null, $objectData = null ) {
+
+		global $wgLoopNumberingType;
+		if ( $previousObjects == null ) {
+			$previousObjects = LoopObjectIndex::getObjectNumberingsForPage ( $lsi, $loopStructure );
+		}
+		if ( $objectData == null ) {
+			$objectData = LoopObjectIndex::getObjectData($objectid, $loopStructure);
+		}
+
+		if ( $objectData["refId"] == $objectid ) {
+			if ( $wgLoopNumberingType == "chapter" ) {
+
+				preg_match('/(\d+)\.{0,1}/', $lsi->tocNumber, $tocChapter);
+
+				if (isset($tocChapter[1])) {
+					$tocChapter = $tocChapter[1];
+				}
+				if ( empty( $tocChapter ) ) {
+					$tocChapter = 0;
+				}
+				return $tocChapter . "." . ( $previousObjects[$objectData["index"]] + $objectData["nthoftype"] );
+				
+			} elseif ( $wgLoopNumberingType == "ongoing" ) {
+				
+				return ( $previousObjects[$objectData["index"]] + $objectData["nthoftype"] );
+					
+			} 
+		}
 	}
 }
 ?>

--- a/includes/LoopObjectIndex.php
+++ b/includes/LoopObjectIndex.php
@@ -93,7 +93,7 @@ class LoopObjectIndex {
     // returns structure objects with numberings in the table
     public static function getAllObjects ( $loopStructure ) {
         
-        global $wgLoopObjectNumbering, $wgLoopNumberingType;
+        global $wgLoopObjectNumbering;
         
         $dbr = wfGetDB( DB_REPLICA );
         
@@ -130,25 +130,15 @@ class LoopObjectIndex {
                 $numberText = '';
                 
                 if ( $wgLoopObjectNumbering == true ) {
-                    if ( $wgLoopNumberingType == 'chapter' ) {
-                        
-                        $tocChapter = '';
-                        preg_match('/(\d+)\.{0,1}/', $lsi->tocNumber, $tocChapterArray);
-                        
-                        if (isset($tocChapterArray[1])) {
-                            $tocChapter = $tocChapterArray[1];
-                        } else {
-                            $tocChapter = 0;
-                        }
-                        
-                        $number = $previousObjects[$row->loi_pageid][$row->loi_index] + $row->loi_nthoftype;
-                        $numberText = $tocChapter . '.' . $number;
-                        
-                    } else {
-                        $numberText = $row->loi_nthoftype + $previousObjects[$row->loi_pageid][$row->loi_index];
-                    }
+                    
+                    $objectData = array(
+                        "refId" => $row->loi_refid,
+                        "index" => $row->loi_index,
+                        "nthoftype" => $row->loi_nthoftype
+                    );
+                    $numberText = LoopObject::getObjectNumberingOutput($row->loi_refid, $lsi, $loopStructure, $previousObjects[$loopStructureItem->article], $objectData);
+			        
                }
-            
             
                $objects[$row->loi_refid] = array(
                    "pageid" => $row->loi_pageid,
@@ -261,6 +251,45 @@ class LoopObjectIndex {
 		}
 		# id is unique in index
 		return true;
-	}
+    }
+    
+    public static function getObjectData( $refId, LoopStructure $loopStructure ) {
+        
+        $dbr = wfGetDB( DB_REPLICA );
+		$res = $dbr->select(
+			'loop_object_index',
+			array(
+                'loi_pageid',
+                'loi_refid',
+                'loi_index',
+                'loi_itemtype',
+                'loi_itemtitle',
+                'loi_nthoftype'
+			),
+			array(
+				'loi_refid = "' . $refId .'"'
+			),
+			__METHOD__
+		);
+		
+		foreach( $res as $row ) {
+
+            $lsi = LoopStructureItem::newFromIds ( $row->loi_pageid );
+            $return = array(
+                'refId' => $row->loi_refid,
+                'articleId' => $row->loi_pageid,
+                'index' => $row->loi_index,
+                'title' => $row->loi_itemtitle,
+                'type' => $row->loi_itemtype,
+                'nthoftype' => $row->loi_nthoftype,
+            );
+
+			return $return;
+
+		}
+		# id unknown
+		return false;
+
+    }
 
 }

--- a/includes/LoopObjectIndex.php
+++ b/includes/LoopObjectIndex.php
@@ -136,7 +136,7 @@ class LoopObjectIndex {
                         "index" => $row->loi_index,
                         "nthoftype" => $row->loi_nthoftype
                     );
-                    $numberText = LoopObject::getObjectNumberingOutput($row->loi_refid, $lsi, $loopStructure, $previousObjects[$loopStructureItem->article], $objectData);
+                    $numberText = LoopObject::getObjectNumberingOutput($row->loi_refid, $lsi, $loopStructure, $previousObjects[$row->loi_pageid], $objectData);
 			        
                }
             

--- a/includes/LoopReference.php
+++ b/includes/LoopReference.php
@@ -51,17 +51,22 @@ class LoopReference {
 				$parser->addTrackingCategory( 'loop-tracking-category-error' );
 				$html = $e . $html;
 			}
-			#dd(	$showTitle, (isset($args["title"]) && strtolower($args["title"]) == "true"), $wgLoopObjectNumbering);
 			if ( isset($objectData) && $objectData ) {
+				
+				$lsi = LoopStructureItem::newFromIds ( $objectData["articleId"] );
+
 				if ( !empty( $input ) ) {
 					$linkTitle .= $parser->recursiveTagParse ( $input, $frame );
-					$linkTitleAttr = wfMessage ( $objectData["index"].'-name-short' )->inContentLanguage ()->text () . " " . $objectData["title"];
+					if ( $wgLoopObjectNumbering ) {
+						if ( $lsi ) {
+							$linkTitleAttr = wfMessage ( $objectData["index"].'-name-short' )->inContentLanguage ()->text () . " ";
+							$linkTitleAttr .= LoopObject::getObjectNumberingOutput($refId, $lsi, $loopStructure, null, $objectData );
+							$linkTitleAttr .= " ".$objectData["title"];
+						}
+					}
 				} else {
 					$linkTitle .= wfMessage ( $objectData["index"].'-name-short' )->inContentLanguage ()->text () . " ";
 					if ( $wgLoopObjectNumbering ) {
-						
-						$lsi = LoopStructureItem::newFromIds ( $objectData["articleId"] );
-							
 						if ( $lsi ) {
 							$linkTitle .= LoopObject::getObjectNumberingOutput($refId, $lsi, $loopStructure, null, $objectData );
 						}
@@ -77,6 +82,7 @@ class LoopReference {
 					array( 
 						"class" => "loop-reference",
 						"title" => $linkTitleAttr,
+						"alt" => $linkTitleAttr,
 						"data-target" => $refId # target id will be added in hook
 						)
 				);

--- a/includes/LoopReference.php
+++ b/includes/LoopReference.php
@@ -1,0 +1,89 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+class LoopReference {
+    public static function onParserSetup(Parser $parser) {
+		$parser->setHook ( 'loop_reference', 'LoopReference::renderLoopReference' );
+		return true;
+    }	
+    
+	/**
+	 *
+	 * @param string $input        	
+	 * @param array $args        	
+	 * @param Parser $parser        	
+	 * @param Frame $frame        	
+	 * @return string
+	 */
+	public static function renderLoopReference($input, array $args, $parser, $frame) {
+		
+		global $wgLoopObjectNumbering;
+		
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+
+      $loopStructure = new LoopStructure();
+			$loopStructure->loadStructureItems();
+			$html = '';
+			$linkTitle = '';
+			try {
+				if ( isset($args["id"]) ) {
+					$refId = $args["id"];
+					$objectData = LoopObjectIndex::getObjectData($refId, $loopStructure);
+				} else {
+					throw new LoopException( wfMessage( 'loopreference-error-no-refid' )->text());
+				}
+
+
+				if ( ! $objectData ) {
+					throw new LoopException( wfMessage( 'loopreference-error-unknown-refid', $refId )->text());
+				}
+				# with title = true args or no numbering, the title is shown in link.
+				if ( (isset($args["title"]) && strtolower($args["title"]) == "true") || !$wgLoopObjectNumbering ) {
+					$showTitle = true;
+				} elseif( !isset($args["title"]) || strtolower($args["title"]) == "false" ) {
+					$showTitle = false;
+				} else {
+					$showTitle = false;
+					throw new LoopException( wfMessage( 'loopreference-error-unknown-titleoption', $args["title"] , "true, false" )->text() );
+				}
+			} catch ( LoopException $e ) {
+				$parser->addTrackingCategory( 'loop-tracking-category-error' );
+				$html = $e . $html;
+			}
+			#dd(	$showTitle, (isset($args["title"]) && strtolower($args["title"]) == "true"), $wgLoopObjectNumbering);
+			if ( isset($objectData) && $objectData ) {
+				if ( !empty( $input ) ) {
+					$linkTitle .= $parser->recursiveTagParse ( $input, $frame );
+					$linkTitleAttr = wfMessage ( $objectData["index"].'-name-short' )->inContentLanguage ()->text () . " " . $objectData["title"];
+				} else {
+					$linkTitle .= wfMessage ( $objectData["index"].'-name-short' )->inContentLanguage ()->text () . " ";
+					if ( $wgLoopObjectNumbering ) {
+						
+						$lsi = LoopStructureItem::newFromIds ( $objectData["articleId"] );
+							
+						if ( $lsi ) {
+							$linkTitle .= LoopObject::getObjectNumberingOutput($refId, $lsi, $loopStructure, null, $objectData );
+						}
+					}
+					if ( $showTitle ) {
+						$linkTitle .= " ".$objectData["title"];
+					}
+					$linkTitleAttr = htmlspecialchars($linkTitle);
+				}
+				$html .= $linkRenderer->makelink( 
+					Title::newFromId($objectData["articleId"]),
+					new HtmlArmor( $linkTitle ),
+					array( 
+						"class" => "loop-reference",
+						"title" => $linkTitleAttr,
+						"data-target" => $refId # target id will be added in hook
+						)
+				);
+			} else {
+				$html .= $parser->recursiveTagParse ( $input, $frame );
+			}
+
+		return  $html;			
+	}
+}

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -753,7 +753,9 @@
 						<xsl:when test="$object_type='loop_figure'">
 							<fo:block>
 								<fo:basic-link>
-									<xsl:attribute name="internal-destination"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+									<xsl:attribute name="internal-destination">
+										<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+									</xsl:attribute>
 									<fo:block>
 									<xsl:if test="php:function('xsl_transform_imagepath', descendant::link/target)!=''">
 										<fo:external-graphic scaling="uniform" content-width="24mm" content-height="scale-to-fit" max-height="20mm">
@@ -772,7 +774,9 @@
 				<fo:table-cell width="140mm">
 					<fo:block text-align-last="justify" text-align="justify">
 						<fo:basic-link color="black">
-							<xsl:attribute name="internal-destination"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+							<xsl:attribute name="internal-destination">
+								<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+							</xsl:attribute>
 							
 							<fo:inline font-weight="bold">
 								<xsl:choose>
@@ -821,7 +825,9 @@
 								</xsl:choose>	
 								<fo:leader leader-pattern="dots"></fo:leader>
 								<fo:page-number-citation>
-									<xsl:attribute name="ref-id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+									<xsl:attribute name="ref-id">
+										<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+									</xsl:attribute>
 								</fo:page-number-citation>
 							</fo:inline>
 						</fo:basic-link>					
@@ -1366,32 +1372,44 @@
 		<!-- <xsl:if test="not(@extension_name='mathimage')"> -->
 		<xsl:if test="@extension_name='loop_figure'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:if test="@extension_name='loop_formula'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:if test="@extension_name='loop_listing'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:if test="@extension_name='loop_media'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:if test="@extension_name='loop_table'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:if test="@extension_name='loop_task'">
 			<fo:inline>
-				  <xsl:attribute name="id"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</fo:inline>			
 		</xsl:if>	
 		<xsl:choose>
@@ -1632,9 +1650,11 @@
 			</xsl:choose>
 		</xsl:variable>
 			
-		<fo:basic-link color="black">
+		<fo:basic-link color="black" text-decoration="underline">
 			<xsl:if test="@id"> 
-				<xsl:attribute name="internal-destination"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+				<xsl:attribute name="internal-destination">
+					<xsl:text>id</xsl:text><xsl:value-of select="@id"></xsl:value-of>
+				</xsl:attribute>
 			</xsl:if>
 		
 			<xsl:choose>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1632,6 +1632,11 @@
 			</xsl:choose>
 		</xsl:variable>
 			
+		<fo:basic-link color="black">
+			<xsl:if test="@id"> 
+				<xsl:attribute name="internal-destination"><xsl:value-of select="generate-id()"></xsl:value-of></xsl:attribute>
+			</xsl:if>
+		
 			<xsl:choose>
 				<xsl:when test="$object=''">
 					<xsl:choose>
@@ -1673,6 +1678,8 @@
 					<xsl:apply-templates/>
 				</xsl:otherwise>
 			</xsl:choose>
+
+		</fo:basic-link>
 
 	</xsl:template>
 	

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1427,6 +1427,11 @@
                 	<xsl:with-param name="object" select="."></xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="@extension_name='loop_reference'">
+				<xsl:call-template name="loop_reference">
+                	<xsl:with-param name="object" select="."></xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>
 			<xsl:otherwise>
 			</xsl:otherwise>
 		</xsl:choose>	
@@ -1611,5 +1616,64 @@
 				
 		</xsl:choose>
 	</xsl:template>	
+
+	
+	<xsl:template name="loop_reference">
+		<xsl:param name="object"></xsl:param>
+
+		<xsl:variable name="objectid">
+			<xsl:choose>
+				<xsl:when test="@id"> 
+					<xsl:value-of select="@id"></xsl:value-of>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text></xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+			
+			<xsl:choose>
+				<xsl:when test="$object=''">
+					<xsl:choose>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_figure'">
+							<xsl:value-of select="$word_figure_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_formula'">
+							<xsl:value-of select="$word_formula_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_listing'">
+							<xsl:value-of select="$word_listing_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_media'">
+							<xsl:value-of select="$word_media_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_task'">
+							<xsl:value-of select="$word_task_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_table'">
+							<xsl:value-of select="$word_table_short"></xsl:value-of>
+						</xsl:when>
+						<xsl:otherwise>
+						</xsl:otherwise>
+					</xsl:choose>
+					<xsl:text> </xsl:text>
+					<xsl:if test="//*/loop_object[@refid = $objectid]/object_number">
+						<xsl:value-of select="//*/loop_object[@refid = $objectid]/object_number"></xsl:value-of>
+					</xsl:if>
+
+					<xsl:if test="$object/@title='true'">
+						<xsl:text> </xsl:text>
+						<xsl:if test="//*/loop_object[@refid = $objectid]/object_title">
+							<xsl:value-of select="//*/loop_object[@refid = $objectid]/object_title"></xsl:value-of>
+						</xsl:if>
+					</xsl:if>
+
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:apply-templates/>
+				</xsl:otherwise>
+			</xsl:choose>
+
+	</xsl:template>
 	
 </xsl:stylesheet>

--- a/xsl/ssml.xsl
+++ b/xsl/ssml.xsl
@@ -110,6 +110,11 @@
                 	<xsl:with-param name="object" select="."></xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="@extension_name='loop_reference'">
+				<xsl:call-template name="loop_reference">
+                	<xsl:with-param name="object" select="."></xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>
 
 			<xsl:when test="@extension_name='loop_title'">
 				<xsl:apply-templates/>
@@ -131,6 +136,65 @@
 					</xsl:attribute>
 				</xsl:element>
 		-->
+	</xsl:template>
+
+
+	<xsl:template name="loop_reference">
+		<xsl:param name="object"></xsl:param>
+
+		<xsl:variable name="objectid">
+			<xsl:choose>
+				<xsl:when test="@id"> 
+					<xsl:value-of select="@id"></xsl:value-of>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text></xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+			
+			<xsl:choose>
+				<xsl:when test="$object=''">
+					<xsl:choose>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_figure'">
+							<xsl:value-of select="$word_figure"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_formula'">
+							<xsl:value-of select="$word_formula"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_listing'">
+							<xsl:value-of select="$word_listing"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_media'">
+							<xsl:value-of select="$word_media"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_task'">
+							<xsl:value-of select="$word_task"></xsl:value-of>
+						</xsl:when>
+						<xsl:when test="//*/loop_object[@refid = $objectid]/@object_type='loop_table'">
+							<xsl:value-of select="$word_table"></xsl:value-of>
+						</xsl:when>
+						<xsl:otherwise>
+						</xsl:otherwise>
+					</xsl:choose>
+					<xsl:text> </xsl:text>
+					<xsl:if test="//*/loop_object[@refid = $objectid]/object_number">
+						<xsl:value-of select="//*/loop_object[@refid = $objectid]/object_number"></xsl:value-of>
+					</xsl:if>
+
+					<xsl:if test="$object/@title='true'">
+						<xsl:text>: </xsl:text>
+						<xsl:if test="//*/loop_object[@refid = $objectid]/object_title">
+							<xsl:value-of select="//*/loop_object[@refid = $objectid]/object_title"></xsl:value-of>
+						</xsl:if>
+					</xsl:if>
+
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:apply-templates/>
+				</xsl:otherwise>
+			</xsl:choose>
+
 	</xsl:template>
 
 	<xsl:template name="loop_object">


### PR DESCRIPTION
Fix #103 
Läuft auf krohn / Kapitel Referenzen.
Man kann Loop Objekte referenzieren, indem man dessen ID im Tag angibt.
PDF und SSML 

Verhalten: 
- wenn Objektzählung an: "Abb. 2"
- wenn Objektzählung aus: "Abb. _Titel_"
- wenn Parameter Title = true: Abb. (2) _Titel_
- wenn Inhalt im Tag (überschreibt Title-Angabe): _Taginhalt_

- wenn keine ID: Fehler
- wenn unbekannte ID: Fehler
- wenn unbekannter Parameter in Title: Fehler

**TODO**: WikiEdidor Implementierung
