### PR TITLE
Loop Objekte und FlaggedRevs Kompatibilität

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -90,7 +90,8 @@
 		],
 		"LinksUpdateConstructed": "LoopObject::onLinksUpdateConstructed",
 		"ArticleDeleteComplete": "LoopObject::onArticleDeleteComplete",
-		"AfterStabilizeChange":"LoopObject::onAfterStabilizeChange"
+		"AfterStabilizeChange":"LoopObject::onAfterStabilizeChange",
+		"AfterClearStable":"LoopObject::onAfterClearStable"
 	},
 	"SpecialPages": {
 		"LoopStructure": "SpecialLoopStructure",

--- a/extension.json
+++ b/extension.json
@@ -90,7 +90,8 @@
 		],
 		"ParserMakeImageParams":[
 			"LoopHooks::onParserMakeImageParams"
-		]
+		],
+		"LinksUpdateConstructed": "LoopObject::onLinksUpdateConstructed"
 	},
 	"SpecialPages": {
 		"LoopStructure": "SpecialLoopStructure",

--- a/extension.json
+++ b/extension.json
@@ -76,9 +76,6 @@
 			"LoopArea::onParserSetup",
 			"LoopReference::onParserSetup"
 		],
-		"PageContentSaveComplete": [
-			"LoopObject::onPageContentSaveComplete"
-		],
 		"ParserAfterTidy": [
 			"LoopObject::onParserAfterTidy"
 		],
@@ -91,7 +88,9 @@
 		"ParserMakeImageParams":[
 			"LoopHooks::onParserMakeImageParams"
 		],
-		"LinksUpdateConstructed": "LoopObject::onLinksUpdateConstructed"
+		"LinksUpdateConstructed": "LoopObject::onLinksUpdateConstructed",
+		"ArticleDeleteComplete": "LoopObject::onArticleDeleteComplete",
+		"AfterStabilizeChange":"LoopObject::onAfterStabilizeChange"
 	},
 	"SpecialPages": {
 		"LoopStructure": "SpecialLoopStructure",

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -105,7 +105,8 @@ class LoopHooks {
 	 * @return boolean
 	 */
 	public static function onParserMakeImageParams( $title, $file, &$params, $parser ) {
-		
+		global $wgOut;
+		$user = $wgOut->getUser();
 		$loopEditMode = $user->getOption( 'LoopEditMode', false, true );
 		$parser->getOptions()->optionUsed( 'LoopEditMode' );
 		#dd($loopEditMode);

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -1120,7 +1120,10 @@ class LoopObject {
 				if ( empty( $tocChapter ) ) {
 					$tocChapter = 0;
 				}
-				return $tocChapter . "." . ( $previousObjects[$objectData["index"]] + $objectData["nthoftype"] );
+				if ( isset($previousObjects[$objectData["index"]]) ) {
+					$tmpPreviousObjects = $previousObjects[$objectData["index"]];
+				}
+				return $tocChapter . "." . ( $tmpPreviousObjects + $objectData["nthoftype"] );
 				
 			} elseif ( $wgLoopNumberingType == "ongoing" ) {
 				$tmpPreviousObjects = 0;

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -792,12 +792,25 @@ class LoopObject {
 	}
 	
 	/**
-	 * Custom hook called after stabilization changes of pages in FlaggableWikiPage->clearStableVersion() and FlaggableWikiPage->updateStableVersion()
-	 * @param LinksUpdate $linksUpdate
+	 * Custom hook called after stabilization changes of pages in FlaggableWikiPage->updateStableVersion()
+	 * @param Title $title
+	 * @param Content $content
 	 */
-	public static function onAfterStabilizeChange ( $title, $content = null ) {
+	public static function onAfterStabilizeChange ( $title, $content ) {
+		error_log("stabilize");
 		$wikiPage = WikiPage::factory($title);
 		self::doIndexLoopObjects( $wikiPage, $title, $content );
+
+		return true;
+	}
+	/**
+	 * Custom hook called after stabilization changes of pages in FlaggableWikiPage->clearStableVersion()
+	 * @param Title $title
+	 */
+	public static function onAfterClearStable( $title ) {
+		error_log("clear");
+		$wikiPage = WikiPage::factory($title);
+		self::doIndexLoopObjects( $wikiPage, $title );
 
 		return true;
 	}

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -790,12 +790,39 @@ class LoopObject {
 		}
 		#$striped_text = $this->getParser()->killMarkers ( $text );
 	}
+	public static function onPageContentSaveComplete( $wikiPage, $user, $content, $summary, $isMinor, $isWatch, $section, &$flags, $revision, $status, $baseRevId, $undidRevId ) {
+		#dd("onPageContentSaveComplete");
+		#self::doOnPageContentSaveComplete( $wikiPage );
+		return true;
+
+	}
+	public static function onLinksUpdateConstructed( $linksUpdate ) { 
+		$title = $linksUpdate->getTitle();
+		$wikiPage = WikiPage::factory( $title );
+		$latestRevId = $title->getLatestRevID();
+		if ( isset($title->flaggedRevsArticle) ) {
+			$stableRevId = $title->flaggedRevsArticle;
+			#dd($title->flaggedRevsArticle);
+			$stableRevId = $stableRevId->getStable();
+			if ( $latestRevId == $stableRevId ) {
+				self::doOnPageContentSaveComplete( $wikiPage, $title );
+			}
+		} else {
+			self::doOnPageContentSaveComplete( $wikiPage, $title );
+		}
+
+		#dd($title->flaggedRevsArticle,$fwp,$latestRevId, $linksUpdate);
+		return true;
+	}
+
 	/**
 	 * Adds objects to db after edit
 	 */
-	public static function onPageContentSaveComplete( $wikiPage, $user, $content, $summary, $isMinor, $isWatch, $section, &$flags, $revision, $status, $baseRevId, $undidRevId ) {
+	public static function doOnPageContentSaveComplete( $wikiPage, $title ) {
 		
 		$title = $wikiPage->getTitle();
+
+		$content = $wikiPage->getContent();
 		if ( $title->getNamespace() == NS_MAIN ) {
 				
 			# on edit, delete all objects of that page from db. 

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -1123,8 +1123,12 @@ class LoopObject {
 				return $tocChapter . "." . ( $previousObjects[$objectData["index"]] + $objectData["nthoftype"] );
 				
 			} elseif ( $wgLoopNumberingType == "ongoing" ) {
+				$tmpPreviousObjects = 0;
+				if ( isset($previousObjects[$objectData["index"]]) ) {
+					$tmpPreviousObjects = $previousObjects[$objectData["index"]];
+				}
 				
-				return ( $previousObjects[$objectData["index"]] + $objectData["nthoftype"] );
+				return ( $tmpPreviousObjects + $objectData["nthoftype"] );
 					
 			} 
 		}

--- a/includes/LoopObjectIndex.php
+++ b/includes/LoopObjectIndex.php
@@ -16,7 +16,7 @@ class LoopObjectIndex {
 	 * @return bool true
 	 */
 	public function addToDatabase() {
-
+       
         $dbw = wfGetDB( DB_MASTER );
         
         $dbw->insert(
@@ -39,7 +39,7 @@ class LoopObjectIndex {
     }
 	
 	// deletes all objects of a page
-    public function removeAllPageItemsFromDb ( $article ) {
+    public static function removeAllPageItemsFromDb ( $article ) {
 
 		$dbr = wfGetDB( DB_MASTER );
 		$dbr->delete(

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -43,14 +43,18 @@ class LoopStructure {
 				} else {
 					$tabLevel = 1;
 				}
-
-				$link = $linkRenderer->makeLink(
-					Title::newFromID( $structureItem->article ),
-					new HtmlArmor( $structureItem->tocNumber .' '. $structureItem->tocText )
-				);
-
+				$title = Title::newFromID( $structureItem->article );
+				$link =  $structureItem->tocNumber .' '. $structureItem->tocText;
+				if ( $title ) {
+					$link = $linkRenderer->makeLink(
+						Title::newFromID( $structureItem->article ),
+						new HtmlArmor( $structureItem->tocNumber .' '. $structureItem->tocText )
+					);
+					
+				} 
 				$text .= '<div class="loopstructure-level-'.$structureItem->tocLevel.'">' . str_repeat('	',  $tabLevel ) . $link . '</div>';
-
+				
+				
 			}
 
 		}


### PR DESCRIPTION
Objekte werden jetzt in der korrekten Form in der DB abgespeichert, auch wenn sich der Stabilitätsstatus ändert.
Dazu wurde Flaggedrevs modifiziert und geforkt: [Link](https://github.com/oncampus/mediawiki-extensions-FlaggedRevs.git) 
Flaggedrevs sollte also mit dem oncampus-Fork ausgetauscht werden, um zu funktionieren (s.u.).

`git remote set-url origin https://github.com/oncampus/mediawiki-extensions-FlaggedRevs.git`
`git pull`