### PR TITLE
Syntaxhighlighting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 	"license": "GPL-3.0-or-later",    
     "require": {
         "composer/installers": "1.*,>=1.0.1",
-        "james-heinrich/getid3": ">=1.9" 
+        "james-heinrich/getid3": ">=1.9" ,
+        "symfony/process": ">=4.3.2" 
     }
 }

--- a/extension.json
+++ b/extension.json
@@ -16,7 +16,8 @@
 		"MediaWiki": ">= 1.32.0",
 		"extensions": {
 			"WikiEditor": "*",
-			"Math": "*"
+			"Math": "*",
+			"SyntaxHighlight": "*"
 		}
 	},
 	"callback": "Loop::onExtensionLoad",

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -94,7 +94,7 @@ class LoopHooks {
 
 	
 	/**
-	 * Remove image link when not in loopeditmode
+	 * Remove image link when not in loopeditmode and add responsive-img class to all images
 	 * 
 	 * This is attached to the MediaWiki 'ParserMakeImageParams' hook.
 	 * 
@@ -109,8 +109,8 @@ class LoopHooks {
 		$user = $wgOut->getUser();
 		$loopEditMode = $user->getOption( 'LoopEditMode', false, true );
 		$parser->getOptions()->optionUsed( 'LoopEditMode' );
-		#dd($loopEditMode);
-		
+		$params['frame']['class'] = 'responsive-image';
+
 		if ($loopEditMode) {
 			$params['frame']['no-link'] = false;
 		} else {

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -34,6 +34,7 @@ class LoopPdf {
 		}
 	
 		#dd($xmlfo); // display xmlfo and exit
+		
 		$url = $wgXmlfo2PdfServiceUrl. '?token='.$wgXmlfo2PdfServiceToken;
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_POST, 1);

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -33,7 +33,7 @@ class LoopPdf {
 			var_dump($e);
 		}
 	
-		#var_dump($xmlfo);exit;
+		#dd($xmlfo); // display xmlfo and exit
 		$url = $wgXmlfo2PdfServiceUrl. '?token='.$wgXmlfo2PdfServiceToken;
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_POST, 1);

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -35,7 +35,6 @@ class LoopPdf {
 	
 		#var_dump($xmlfo);exit;
 		$url = $wgXmlfo2PdfServiceUrl. '?token='.$wgXmlfo2PdfServiceToken;
-		
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_POST, 1);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml'));

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -2,7 +2,6 @@
 class LoopXml {
 	
 	/**
-	 * Add indexable item to the database
 	 * @param LoopStructure $loopStructure: 
 	 * @param Array $modifiers: 
 	 * 		"mp3" => true; modifies XML Output for MP3 export, adds additional breaks for loop_objects
@@ -71,6 +70,12 @@ class LoopXml {
 	    return $xml;
 	}
 	
+	/**
+	 * Converts structure items to XML code
+	 * @param LoopStructureItem $structureItem: 
+	 * @param Array $modifiers: 
+	 * 		"mp3" => true; modifies XML Output for MP3 export, adds additional breaks for loop_objects
+	 */
 	public static function structureItem2xml(LoopStructureItem $structureItem, Array $modifiers = null) {
 		#$content = WikiPage::newFromID ( $structureItem->getArticle () )->getContent ( Revision::RAW )->getNativeData ();
 		
@@ -81,10 +86,14 @@ class LoopXml {
 			$stableRev = $structureItem->getArticle ();
 		}
 		$content = Revision::newFromId( $stableRev )->getContent (  )->getNativeData ();
-		
 		$content = html_entity_decode($content);
 		$objectTypes = LoopObject::$mObjectTypes;
 		#dd();
+
+		# modify content for resolving space issues with syntaxhighlight in pdf
+		$content = preg_replace('/(<syntaxhighlight.*)(>)(.*)(<\/syntaxhighlight>)/U', "$1$2$3\n$4", $content);
+		
+		#dd($content);
 		# modify content for mp3 export
 		if ( $modifiers["mp3"] ) {
 			foreach( $objectTypes as $type ) {

--- a/xsl/LoopXsl.php
+++ b/xsl/LoopXsl.php
@@ -1,5 +1,11 @@
 <?php 
 
+/**
+ * Transforms image paths into absolute server paths
+ * Called for PDF process
+ * @param DomNode $input
+ * @return String $return
+ */
 function xsl_transform_imagepath($input) {
 	$imagepath='';
 	if (is_array($input)) {
@@ -28,25 +34,31 @@ function xsl_transform_imagepath($input) {
 		}
 	} else {
 		#$target_uri=trim($input_array[1]);
-			$filetitle=Title::newFromText( $input, NS_FILE );
-			$file = wfLocalFile($filetitle);
-			if (is_object($file)) {
-				$imagepath=$file->getFullUrl();
-				if ( file_exists($file->getLocalRefPath()) ) {
-					
-					return $imagepath;
-				} else {
-					
-					return '';
-				}
+		$filetitle=Title::newFromText( $input, NS_FILE );
+		$file = wfLocalFile($filetitle);
+		if (is_object($file)) {
+			$imagepath=$file->getFullUrl();
+			if ( file_exists($file->getLocalRefPath()) ) {
+				
+				return $imagepath;
 			} else {
 				
 				return '';
 			}
+		} else {
+			
+			return '';
+		}
 	}
 }
 
 
+/**
+ * Transforms math tag into math text
+ * Called for PDF process
+ * @param DomNode $input
+ * @return String $return
+ */
 function xsl_transform_math($input) {
 	global $IP;
 	$input_object = $input[0];
@@ -77,6 +89,12 @@ function xsl_transform_math($input) {
 	
 }
 
+/**
+ * Transforms math tag into spoken text
+ * Called for Audio process
+ * @param DomNode $input
+ * @return String $return
+ */
 function xsl_transform_math_ssml($input) {
 	global $wgMathMathMLUrl;
 	$input_object = $input[0];
@@ -99,101 +117,129 @@ function xsl_error_handler($errno, $errstr, $errfile, $errline) {
 	return true;
 }
 
-
+/**
+ * Transforms syntaxhighlight XML and processes it into highlighted text
+ * Called for PDF process
+ * @param DomNode $input
+ * @return DomDocument $return
+ */
 function xsl_transform_syntaxhighlight($input) {
 	
 	global $wgPygmentizePath, $IP, $wgScriptPath;
 	
-	$return = '';
+	$symfonyPath = "$IP/extensions/Loop/vendor/symfony/process/";
+
+	if ( is_file( $symfonyPath . "Process.php" ) ) {
+	
+		$return = '';
+		$input_object=$input[0];
+		
+		$dom = new DOMDocument( "1.0", "utf-8" );
+		$dom->appendChild($dom->importNode($input_object, true));
+		$xml = $dom->saveXML();
+
+		$xml = str_replace('<space/>',' ',$xml);
+		$xml = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $xml); 
+		$xml = preg_replace("/^(<extension)(.*)(>)/", "", $xml);
+		$xml = preg_replace("/(<\/extension>)$/", "", $xml);
+		$xml = trim ($xml, " \n\r");
+
+		$xml = htmlspecialchars_decode ($xml);
+
+		$code = $xml;
+	
+		require_once $symfonyPath . "Process.php";
+		require_once $symfonyPath . "ProcessUtils.php";
+		require_once $symfonyPath . "Pipes/PipesInterface.php";
+		require_once $symfonyPath . "Pipes/AbstractPipes.php";
+		require_once $symfonyPath . "Pipes/UnixPipes.php";
+		
+		
+		if ($input_object->hasAttribute('lang')) {
+			$lexer = $input_object->getAttribute('lang');
+			$lang = $input_object->getAttribute('lang');
+		} else {
+			$lexer = 'xml';
+		}
+		# doc for command: http://pygments.org/docs/formatters/#HtmlFormatter
+		$command = array( "-l", $lexer ); # defines lexer (language to highlight in)
+
+		# we ignore the 'inline' attribute as we need to have line breaks on paper
+
+		/* 	# as standard, line numbers should be shown! 
+			# because line-breaking is mandatory, line numbers indicate actual new lines so users can tell the difference
+		if ($input_object->hasAttribute('line')) {
+			$line = $input_object->getAttribute('line');
+			$command[] = "-O";
+			$command[] = "linenos=inline";
+		} */
+		if ($input_object->hasAttribute('start') ) { # defines the start option of line numbering
+			$start = $input_object->getAttribute('start');
+			$command[] = "-O";
+			$command[] = "linenostart=" . $start;
+		}
+		if ($input_object->hasAttribute('highlight')) { # highlights given lines
+			$highlight = $input_object->getAttribute('highlight');
+			$command[] = "-O";
+			$command[] = "hl_lines=$highlight";
+		}
+
+		$command = array_merge ( [ $wgPygmentizePath, "-f", "html", "-O", "encoding=utf-8", "-O", "cssclass", "-O", "startinline=true" ], $command );
+
+		$process = new Symfony\Component\Process\Process( $command, null, null, $code );
+		$process->run();
+		
+		if ( !$process->isSuccessful() ) {
+			$output ='';
+		} else {
+			$output = $process->getOutput();
+		}
+		#var_dump($output); dd($output, $xml,$lexer, $code, $process);
+
+		$output = '<pre>'.$output.'</pre>';
+		$return = new DOMDocument;
+		
+		$old_error_handler = set_error_handler("xsl_error_handler");
+		libxml_use_internal_errors(true);
+		
+		try {
+			$return->loadXml($output);
+		} catch ( Exception $e ) {
+		
+		}
+		restore_error_handler();	
+
+		return $return;
+	} else {
+		# if symfony/process is not present, just return the input node
+		return $input[0];
+	}
+	
+}
+
+/**
+ * Adds linebreaks to a Domnode code tag
+ * Called for PDF process
+ * @param DomNode $input
+ * @return DomNode $codeTag
+ */
+function xsl_transform_code($input) {
 	
 	$input_object=$input[0];
 	
-	if ($input_object->hasAttribute('lang')) {
-		$lexer = $input_object->getAttribute('lang');
-	} else {
-		$lexer = 'xml';
-	}
-	
-	if ($input_object->hasAttribute('lang')) {
-		$lang = $input_object->getAttribute('lang');
-	}
-	if ($input_object->hasAttribute('line')) {
-		$line = $input_object->getAttribute('line');
-	}
-	if ($input_object->hasAttribute('start')) {
-		$start = $input_object->getAttribute('start');
-	}
-	if ($input_object->hasAttribute('highlight')) {
-		$highlight = $input_object->getAttribute('highlight');
-	}
-	if ($input_object->hasAttribute('inline')) {
-		$inline = $input_object->getAttribute('inline');
-	}	
-
 	$dom = new DOMDocument( "1.0", "utf-8" );
 	$dom->appendChild($dom->importNode($input_object, true));
 	
 	
 	$xml = $dom->saveXML();
+	$xml = str_replace('<space/>', ' ',$xml);
+	$xml = preg_replace("/(\s\\t)/","\n\t", $xml);
+	
+	$dom2 = new DOMDocument( "1.0", "utf-8" );
+	$dom2->loadXML($xml);
+	$codeTags = $dom2->getElementsByTagNameNS ("http://www.w3.org/1999/xhtml", "code"); # finds <xhtml:code> tags
+	$codeTag = $codeTags[0];
 
-	$xml = str_replace('<space/>',' ',$xml);
-	$xml = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $xml); 
-	$xml = preg_replace("/^(<extension)(.*)(>)/", "", $xml);
-	$xml = preg_replace("/(<\/extension>)$/", "", $xml);
-	
-	$xml = trim ($xml, " \n\r");
-	$xml = htmlspecialchars_decode ($xml);
-	
-	$code = $xml;
-	
-	$symfonyPath = "$IP/extensions/Loop/vendor/symfony/process/";
-	require_once $symfonyPath . "Process.php";
-	require_once $symfonyPath . "ProcessUtils.php";
-	require_once $symfonyPath . "Pipes/PipesInterface.php";
-	require_once $symfonyPath . "Pipes/AbstractPipes.php";
-	require_once $symfonyPath . "Pipes/UnixPipes.php";
-	
-	/*
-	$code = '<syntaxhighlight lang="python" line="1" >
-def quickSort(arr):
-    less = []
-    pivotList = []
-    more = []
-    if len(arr) <= 1:
-        return arr
-    else:
-       pass
-</syntaxhighlight>';
-	$lexer = 'python';
-*/
-	$process = new Symfony\Component\Process\Process( [ $wgPygmentizePath, "-l", $lexer, "-f", "html", "-O", "encoding=utf-8", "-O", "linenos=inline", "-O", "startinline=true", "-O", "cssclass"], null, null, $code );
-	$process->run();
-	
-	if ( !$process->isSuccessful() ) {
-		dd("not successful, ".$process->getExitCode(), $process);
-		$output ='';
-	} else {
-		$output = $process->getOutput();
-	}
-	#var_dump($output);
-	#dd($output, $xml,$lexer, $code, $process);
+	return $codeTag;
 
-	$output = '<pre>'.$output.'</pre>';
-	$return = new DOMDocument;
-	
-	$old_error_handler = set_error_handler("xsl_error_handler");
-	libxml_use_internal_errors(true);
-	
-	try {
-		$return->loadXml($output);
-	} catch ( Exception $e ) {
-	
-	}
-	restore_error_handler();	
-	
-
-#	$return = $doc->documentElement;
-	#dd($output);
-	return $return;
-	
 }

--- a/xsl/LoopXsl.php
+++ b/xsl/LoopXsl.php
@@ -162,7 +162,7 @@ function xsl_transform_syntaxhighlight($input) {
 			$lexer = 'xml';
 		}
 		# doc for command: http://pygments.org/docs/formatters/#HtmlFormatter
-		$command = array( "-l", $lexer ); # defines lexer (language to highlight in)
+		$command = array( "-l", $lexer, "-O", "linenos=inline" ); # defines lexer (language to highlight in)
 
 		# we ignore the 'inline' attribute as we need to have line breaks on paper
 

--- a/xsl/LoopXsl.php
+++ b/xsl/LoopXsl.php
@@ -98,3 +98,102 @@ function xsl_transform_math_ssml($input) {
 function xsl_error_handler($errno, $errstr, $errfile, $errline) {
 	return true;
 }
+
+
+function xsl_transform_syntaxhighlight($input) {
+	
+	global $wgPygmentizePath, $IP, $wgScriptPath;
+	
+	$return = '';
+	
+	$input_object=$input[0];
+	
+	if ($input_object->hasAttribute('lang')) {
+		$lexer = $input_object->getAttribute('lang');
+	} else {
+		$lexer = 'xml';
+	}
+	
+	if ($input_object->hasAttribute('lang')) {
+		$lang = $input_object->getAttribute('lang');
+	}
+	if ($input_object->hasAttribute('line')) {
+		$line = $input_object->getAttribute('line');
+	}
+	if ($input_object->hasAttribute('start')) {
+		$start = $input_object->getAttribute('start');
+	}
+	if ($input_object->hasAttribute('highlight')) {
+		$highlight = $input_object->getAttribute('highlight');
+	}
+	if ($input_object->hasAttribute('inline')) {
+		$inline = $input_object->getAttribute('inline');
+	}	
+
+	$dom = new DOMDocument( "1.0", "utf-8" );
+	$dom->appendChild($dom->importNode($input_object, true));
+	
+	
+	$xml = $dom->saveXML();
+
+	$xml = str_replace('<space/>',' ',$xml);
+	$xml = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $xml); 
+	$xml = preg_replace("/^(<extension)(.*)(>)/", "", $xml);
+	$xml = preg_replace("/(<\/extension>)$/", "", $xml);
+	
+	$xml = trim ($xml, " \n\r");
+	$xml = htmlspecialchars_decode ($xml);
+	
+	$code = $xml;
+	
+	$symfonyPath = "$IP/extensions/Loop/vendor/symfony/process/";
+	require_once $symfonyPath . "Process.php";
+	require_once $symfonyPath . "ProcessUtils.php";
+	require_once $symfonyPath . "Pipes/PipesInterface.php";
+	require_once $symfonyPath . "Pipes/AbstractPipes.php";
+	require_once $symfonyPath . "Pipes/UnixPipes.php";
+	
+	/*
+	$code = '<syntaxhighlight lang="python" line="1" >
+def quickSort(arr):
+    less = []
+    pivotList = []
+    more = []
+    if len(arr) <= 1:
+        return arr
+    else:
+       pass
+</syntaxhighlight>';
+	$lexer = 'python';
+*/
+	$process = new Symfony\Component\Process\Process( [ $wgPygmentizePath, "-l", $lexer, "-f", "html", "-O", "encoding=utf-8", "-O", "linenos=inline", "-O", "startinline=true", "-O", "cssclass"], null, null, $code );
+	$process->run();
+	
+	if ( !$process->isSuccessful() ) {
+		dd("not successful, ".$process->getExitCode(), $process);
+		$output ='';
+	} else {
+		$output = $process->getOutput();
+	}
+	#var_dump($output);
+	#dd($output, $xml,$lexer, $code, $process);
+
+	$output = '<pre>'.$output.'</pre>';
+	$return = new DOMDocument;
+	
+	$old_error_handler = set_error_handler("xsl_error_handler");
+	libxml_use_internal_errors(true);
+	
+	try {
+		$return->loadXml($output);
+	} catch ( Exception $e ) {
+	
+	}
+	restore_error_handler();	
+	
+
+#	$return = $doc->documentElement;
+	#dd($output);
+	return $return;
+	
+}

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1813,8 +1813,9 @@
 	
 	<xsl:template match="xhtml:code">
 	
-		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" white-space="pre" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
-			<xsl:apply-templates/>
+		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
+			<xsl:apply-templates select="php:function('xsl_transform_code', .)" mode="syntaxhighlight"></xsl:apply-templates>
+			<!-- <xsl:apply-templates></xsl:apply-templates> -->
 		</fo:block>
 
 	</xsl:template>
@@ -1823,7 +1824,7 @@
 		<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
 	</xsl:template>
 	<xsl:template match="div" mode="syntaxhighlight">
-		<fo:block width="50mm" linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" white-space="pre" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
+		<fo:block linefeed-treatment="preserve" white-space-collapse="false" hyphenation-character=" " white-space-treatment="preserve" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
 			<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
 		</fo:block>
 	</xsl:template>	

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1549,6 +1549,14 @@
                 	<xsl:with-param name="object" select="."></xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>
+			
+			<xsl:when test="@extension_name='syntaxhighlight'">
+				<fo:inline>
+					<xsl:apply-templates select="php:function('xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
+					<!-- <xsl:copy-of select="php:function('xsl_transform_syntaxhighlight', .)"></xsl:copy-of> -->
+				</fo:inline>
+			</xsl:when>
+
 			<xsl:otherwise>
 			</xsl:otherwise>
 		</xsl:choose>	
@@ -1801,5 +1809,114 @@
 		</fo:basic-link>
 
 	</xsl:template>
+
+	
+	<xsl:template match="xhtml:code">
+	
+		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" white-space="pre" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
+			<xsl:apply-templates/>
+		</fo:block>
+
+	</xsl:template>
+	
+	<xsl:template match="pre" mode="syntaxhighlight">
+		<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
+	</xsl:template>
+	<xsl:template match="div" mode="syntaxhighlight">
+		<fo:block width="50mm" linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" white-space="pre" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
+			<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
+		</fo:block>
+	</xsl:template>	
+	
+
+	<xsl:template match="span" mode="syntaxhighlight">
+			<fo:wrapper width="50mm" wrap-option="wrap">
+		<xsl:choose>
+			<xsl:when test="@class='lineno'">
+				<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
+			</xsl:when>
+			
+<xsl:when test="@class='nbsp'"><fo:inline white-space="pre"><xsl:value-of select="."></xsl:value-of></fo:inline></xsl:when>
+<xsl:when test="@class='p'"><fo:inline><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='n'"><fo:inline><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='hll'"><fo:inline background-color="#ffffcc"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+
+<xsl:when test="@class='c'"><fo:inline color="#408080"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='err'"><fo:inline border-bottom="1px solid #FF0000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='k'"><fo:inline color="#008000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='o'"><fo:inline color="#666666 "><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='cm'"><fo:inline color="#408080" font-style="italic"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='cp'"><fo:inline color="#BC7A00"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='c1'"><fo:inline color="#408080" font-style="italic"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='cs'"><fo:inline color="#408080" font-style="italic"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gd'"><fo:inline color="#A00000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='ge'"><fo:inline font-style="italic"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gr'"><fo:inline color="#FF0000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gh'"><fo:inline color="#000080" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gi'"><fo:inline color="#00A000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='go'"><fo:inline color="#888888"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gp'"><fo:inline color="#000080" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gs'"><fo:inline font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gu'"><fo:inline color="#800080" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='gt'"><fo:inline color="#0044DD"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kc'"><fo:inline color="#008000" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kd'"><fo:inline color="#008000" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kn'"><fo:inline color="#008000" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kp'"><fo:inline color="#008000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kr'"><fo:inline color="#008000" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='kt'"><fo:inline color="#B00040"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='m'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='s'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='na'"><fo:inline color="#7D9029"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nb'"><fo:inline color="#008000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nc'"><fo:inline color="#0000FF" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='no'"><fo:inline color="#880000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nd'"><fo:inline color="#AA22FF"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='ni'"><fo:inline color="#999999" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='ne'"><fo:inline color="#D2413A" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nf'"><fo:inline color="#0000FF"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nl'"><fo:inline color="#A0A000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nn'"><fo:inline color="#0000FF" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nt'"><fo:inline color="#008000" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='nv'"><fo:inline color="#19177C"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='ow'"><fo:inline color="#AA22FF" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='w'"><fo:inline color="#bbbbbb"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='mb'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='mf'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='mh'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='mi'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='mo'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='sb'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='sc'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='sd'"><fo:inline color="#BA2121" font-style="italic"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when><!-- ; font-style: italic } /* Literal.String.Doc */ -->
+<xsl:when test="@class='s2'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='se'"><fo:inline color="#BB6622" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when><!-- ; font-weight: bold } /* Literal.String.Escape */ -->
+<xsl:when test="@class='sh'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='si'"><fo:inline color="#BB6688" font-weight="bold"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when><!-- ; font-weight: bold } /* Literal.String.Interpol */ -->
+<xsl:when test="@class='sx'"><fo:inline color="#008000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='sr'"><fo:inline color="#BB6688"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='s1'"><fo:inline color="#BA2121"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='ss'"><fo:inline color="#19177C"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='bp'"><fo:inline color="#008000"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='vc'"><fo:inline color="#19177C"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='vg'"><fo:inline color="#19177C"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='vi'"><fo:inline color="#19177C"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+<xsl:when test="@class='il'"><fo:inline color="#666666"><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>
+			
+<xsl:when test="@class='x'"><fo:inline ><xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates></fo:inline></xsl:when>			
+			
+			
+			
+			<xsl:otherwise>
+			
+				<!-- C<xsl:value-of select="@class"></xsl:value-of>D<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates> -->
+				<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
+			</xsl:otherwise>
+		</xsl:choose>
+		
+				</fo:wrapper>
+	</xsl:template>
+	
+	
 	
 </xsl:stylesheet>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1233,7 +1233,7 @@
 		
 
 	<!-- Loop Spoiler -->
-	<xsl:template match="extension[@extension_name='spoiler']">
+	<xsl:template name="spoiler">
 		<xsl:choose>
 			<xsl:when test="(@type='in_text') or (@type='in_text_transparent')">
 				<fo:inline axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" font-weight="bold"  padding-left="1mm" padding-right="1mm" padding-top="1mm" padding-bottom="1mm" border-style="solid" border-width="0.3mm" border-color="{$accent_color}">
@@ -1281,7 +1281,7 @@
 	
 	<!--  		<fo:table table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
  -->
-		<fo:table width="150mm" table-layout="fixed" border-collapse="separate" border-style="solid" border-width="0.3mm" border-color="{$accent_color}">
+		<fo:table width="150mm" table-layout="fixed" border-collapse="separate" border-style="solid" border-width="0.3mm" border-color="{$accent_color}" margin-bottom="5mm">
 			<fo:table-body>
 				<fo:table-row>
 					<fo:table-cell width="1500mm">
@@ -1623,6 +1623,12 @@
 					<xsl:apply-templates select="php:function('xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
 					<!-- <xsl:copy-of select="php:function('xsl_transform_syntaxhighlight', .)"></xsl:copy-of> -->
 				</fo:inline>
+			</xsl:when>
+			<xsl:when test="@extension_name='loop_spoiler'">
+				<xsl:call-template name="spoiler"></xsl:call-template>
+			</xsl:when>
+			<xsl:when test="@extension_name='spoiler'">
+				<xsl:call-template name="spoiler"></xsl:call-template>
 			</xsl:when>
 
 			<xsl:otherwise>

--- a/xsl/pdf_params.xml
+++ b/xsl/pdf_params.xml
@@ -5,7 +5,7 @@
 
 	<hyphenate>true</hyphenate>
 
-	<font_family>Cambria, 'Cambria Math', NotoSerif, NotoSerifCJK, loopfont</font_family>
+	<font_family>Cambria, 'Cambria Math', NotoSerif, NotoSerifCJK, loopfont, SourceCodePro</font_family>
 	
 	<accent_color>gray</accent_color>
 </config>

--- a/xsl/ssml.xsl
+++ b/xsl/ssml.xsl
@@ -158,10 +158,25 @@
 				<xsl:value-of select="$phrase_looparea_start"></xsl:value-of>
 				<xsl:text> </xsl:text>
 				<xsl:value-of select="$looparea_type"></xsl:value-of>
+				<xsl:element name="break">
+					<xsl:attribute name="strength">
+						<xsl:text>strong</xsl:text>
+					</xsl:attribute>
+				</xsl:element>
 				<xsl:apply-templates/>
+				<xsl:element name="break">
+					<xsl:attribute name="strength">
+						<xsl:text>strong</xsl:text>
+					</xsl:attribute>
+				</xsl:element>
 				<xsl:value-of select="$phrase_looparea_end"></xsl:value-of>
 				<xsl:text> </xsl:text>
 				<xsl:value-of select="$looparea_type"></xsl:value-of>
+				<xsl:element name="break">
+					<xsl:attribute name="strength">
+						<xsl:text>strong</xsl:text>
+					</xsl:attribute>
+				</xsl:element>
 			</xsl:when>
 
 			<xsl:when test="@extension_name='math'">
@@ -184,6 +199,22 @@
 
 			<xsl:when test="@extension_name='syntaxhighlight'">
 				<xsl:call-template name="syntaxhighlight"></xsl:call-template>
+			</xsl:when>	
+
+			<xsl:when test="@extension_name='loop_spoiler'">
+				<xsl:call-template name="loop_spoiler">
+                	<xsl:with-param name="object">
+						<xsl:copy-of select="."></xsl:copy-of>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>	
+
+			<xsl:when test="@extension_name='spoiler'">
+				<xsl:call-template name="loop_spoiler">
+                	<xsl:with-param name="object">
+						<xsl:copy-of select="."></xsl:copy-of>
+					</xsl:with-param>
+				</xsl:call-template>
 			</xsl:when>	
 
 			
@@ -225,6 +256,56 @@
 
 	<xsl:template name="syntaxhighlight">
 		<xsl:value-of select="$phrase_syntaxhighlight"></xsl:value-of>
+	</xsl:template>
+	
+	<xsl:template name="loop_spoiler">
+		<xsl:param name="object"></xsl:param>
+
+		<xsl:element name="break">
+			<xsl:attribute name="strength">
+				<xsl:text>medium</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
+		
+		<xsl:choose>
+			<xsl:when test="./descendant::extension[@extension_name='loop_spoiler_text']">
+				<xsl:apply-templates select="./descendant::extension[@extension_name='loop_spoiler_text']" mode="loop_object"></xsl:apply-templates>
+			</xsl:when>
+			<xsl:when test="@text">
+				<xsl:value-of select="@text"></xsl:value-of>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$word_spoiler_defaulttitle"></xsl:value-of>
+			</xsl:otherwise>
+		</xsl:choose>	
+
+		<xsl:element name="break">
+			<xsl:attribute name="strength">
+				<xsl:text>strong</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
+
+		<xsl:text> </xsl:text>
+		<xsl:value-of select="$phrase_spoiler_start"></xsl:value-of>
+		<xsl:element name="break">
+			<xsl:attribute name="strength">
+				<xsl:text>strong</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
+		<xsl:text> </xsl:text>
+		<xsl:apply-templates/>
+		<xsl:element name="break">
+			<xsl:attribute name="strength">
+				<xsl:text>strong</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
+		<xsl:value-of select="$phrase_spoiler_end"></xsl:value-of>
+		<xsl:text> </xsl:text>
+		<xsl:element name="break">
+			<xsl:attribute name="strength">
+				<xsl:text>strong</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
 	</xsl:template>
 
 

--- a/xsl/ssml.xsl
+++ b/xsl/ssml.xsl
@@ -122,7 +122,46 @@
 			</xsl:when>
 
 			<xsl:when test="@extension_name='loop_area'">
+
+				<xsl:variable name="looparea_type">
+					<xsl:choose> <!-- todo: trying to find a way to do this a much shorter way -->
+						<xsl:when test="@type='task'"><xsl:value-of select="$word_looparea_task"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='timerequirement'"><xsl:value-of select="$word_looparea_timerequirement"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='learningobjectives'"><xsl:value-of select="$word_looparea_learningobjectives"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='arrangement'"><xsl:value-of select="$word_looparea_arrangement"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='example'"><xsl:value-of select="$word_looparea_example"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='reflection'"><xsl:value-of select="$word_looparea_reflection"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='notice'"><xsl:value-of select="$word_looparea_notice"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='important'"><xsl:value-of select="$word_looparea_important"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='annotation'"><xsl:value-of select="$word_looparea_annotation"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='definition'"><xsl:value-of select="$word_looparea_definition"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='formula'"><xsl:value-of select="$word_looparea_formula"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='markedsentence'"><xsl:value-of select="$word_looparea_markedsentence"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='sourcecode'"><xsl:value-of select="$word_looparea_sourcecode"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='summary'"><xsl:value-of select="$word_looparea_summary"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='indentation'"><xsl:value-of select="$word_looparea_indentation"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='norm'"><xsl:value-of select="$word_looparea_norm"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='law'"><xsl:value-of select="$word_looparea_law"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='question'"><xsl:value-of select="$word_looparea_question"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='practice'"><xsl:value-of select="$word_looparea_practice"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='exercise'"><xsl:value-of select="$word_looparea_exercise"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='websource'"><xsl:value-of select="$word_looparea_websource"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='experiment'"><xsl:value-of select="$word_looparea_experiment"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
+						<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
+						<xsl:otherwise>
+							<xsl:if test="@icontext"><xsl:value-of select="@icontext"></xsl:value-of></xsl:if>
+						</xsl:otherwise> <!-- todo: error msg? -->
+					</xsl:choose>
+				</xsl:variable>
+			
+				<xsl:value-of select="$phrase_looparea_start"></xsl:value-of>
+				<xsl:text> </xsl:text>
+				<xsl:value-of select="$looparea_type"></xsl:value-of>
 				<xsl:apply-templates/>
+				<xsl:value-of select="$phrase_looparea_end"></xsl:value-of>
+				<xsl:text> </xsl:text>
+				<xsl:value-of select="$looparea_type"></xsl:value-of>
 			</xsl:when>
 
 			<xsl:when test="@extension_name='math'">
@@ -141,6 +180,10 @@
 			</xsl:when>	
 			<xsl:when test="@extension_name='loop_copyright'">
 				<xsl:apply-templates/>
+			</xsl:when>	
+
+			<xsl:when test="@extension_name='syntaxhighlight'">
+				<xsl:call-template name="syntaxhighlight"></xsl:call-template>
 			</xsl:when>	
 
 			
@@ -178,6 +221,10 @@
 
 		<xsl:text> </xsl:text>
 
+	</xsl:template>
+
+	<xsl:template name="syntaxhighlight">
+		<xsl:value-of select="$phrase_syntaxhighlight"></xsl:value-of>
 	</xsl:template>
 
 
@@ -445,6 +492,9 @@
 			</xsl:when>
 			<xsl:when test="extension[@extension_name='loop_area']">
         		<func:result>3</func:result>
+			</xsl:when>
+			<xsl:when test="extension[@extension_name='syntaxhighlight']">
+        		<func:result>2</func:result>
 			</xsl:when>
 
 			<xsl:otherwise>

--- a/xsl/ssml.xsl
+++ b/xsl/ssml.xsl
@@ -122,61 +122,7 @@
 			</xsl:when>
 
 			<xsl:when test="@extension_name='loop_area'">
-
-				<xsl:variable name="looparea_type">
-					<xsl:choose> <!-- todo: trying to find a way to do this a much shorter way -->
-						<xsl:when test="@type='task'"><xsl:value-of select="$word_looparea_task"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='timerequirement'"><xsl:value-of select="$word_looparea_timerequirement"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='learningobjectives'"><xsl:value-of select="$word_looparea_learningobjectives"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='arrangement'"><xsl:value-of select="$word_looparea_arrangement"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='example'"><xsl:value-of select="$word_looparea_example"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='reflection'"><xsl:value-of select="$word_looparea_reflection"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='notice'"><xsl:value-of select="$word_looparea_notice"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='important'"><xsl:value-of select="$word_looparea_important"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='annotation'"><xsl:value-of select="$word_looparea_annotation"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='definition'"><xsl:value-of select="$word_looparea_definition"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='formula'"><xsl:value-of select="$word_looparea_formula"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='markedsentence'"><xsl:value-of select="$word_looparea_markedsentence"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='sourcecode'"><xsl:value-of select="$word_looparea_sourcecode"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='summary'"><xsl:value-of select="$word_looparea_summary"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='indentation'"><xsl:value-of select="$word_looparea_indentation"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='norm'"><xsl:value-of select="$word_looparea_norm"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='law'"><xsl:value-of select="$word_looparea_law"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='question'"><xsl:value-of select="$word_looparea_question"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='practice'"><xsl:value-of select="$word_looparea_practice"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='exercise'"><xsl:value-of select="$word_looparea_exercise"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='websource'"><xsl:value-of select="$word_looparea_websource"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='experiment'"><xsl:value-of select="$word_looparea_experiment"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
-						<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
-						<xsl:otherwise>
-							<xsl:if test="@icontext"><xsl:value-of select="@icontext"></xsl:value-of></xsl:if>
-						</xsl:otherwise> <!-- todo: error msg? -->
-					</xsl:choose>
-				</xsl:variable>
-			
-				<xsl:value-of select="$phrase_looparea_start"></xsl:value-of>
-				<xsl:text> </xsl:text>
-				<xsl:value-of select="$looparea_type"></xsl:value-of>
-				<xsl:element name="break">
-					<xsl:attribute name="strength">
-						<xsl:text>strong</xsl:text>
-					</xsl:attribute>
-				</xsl:element>
-				<xsl:apply-templates/>
-				<xsl:element name="break">
-					<xsl:attribute name="strength">
-						<xsl:text>strong</xsl:text>
-					</xsl:attribute>
-				</xsl:element>
-				<xsl:value-of select="$phrase_looparea_end"></xsl:value-of>
-				<xsl:text> </xsl:text>
-				<xsl:value-of select="$looparea_type"></xsl:value-of>
-				<xsl:element name="break">
-					<xsl:attribute name="strength">
-						<xsl:text>strong</xsl:text>
-					</xsl:attribute>
-				</xsl:element>
+				<xsl:call-template name="loop_area"> </xsl:call-template>
 			</xsl:when>
 
 			<xsl:when test="@extension_name='math'">
@@ -228,6 +174,70 @@
 		-->
 	</xsl:template>
 	
+	
+	<xsl:template name="loop_area">
+
+		<xsl:variable name="looparea_type">
+		<xsl:choose> <!-- todo: trying to find a way to do this a much shorter way -->
+			<xsl:when test="@type='task'"><xsl:value-of select="$word_looparea_task"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='timerequirement'"><xsl:value-of select="$word_looparea_timerequirement"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='learningobjectives'"><xsl:value-of select="$word_looparea_learningobjectives"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='arrangement'"><xsl:value-of select="$word_looparea_arrangement"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='example'"><xsl:value-of select="$word_looparea_example"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='reflection'"><xsl:value-of select="$word_looparea_reflection"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='notice'"><xsl:value-of select="$word_looparea_notice"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='important'"><xsl:value-of select="$word_looparea_important"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='annotation'"><xsl:value-of select="$word_looparea_annotation"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='definition'"><xsl:value-of select="$word_looparea_definition"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='formula'"><xsl:value-of select="$word_looparea_formula"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='markedsentence'"><xsl:value-of select="$word_looparea_markedsentence"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='sourcecode'"><xsl:value-of select="$word_looparea_sourcecode"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='summary'"><xsl:value-of select="$word_looparea_summary"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='indentation'"><xsl:value-of select="$word_looparea_indentation"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='norm'"><xsl:value-of select="$word_looparea_norm"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='law'"><xsl:value-of select="$word_looparea_law"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='question'"><xsl:value-of select="$word_looparea_question"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='practice'"><xsl:value-of select="$word_looparea_practice"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='exercise'"><xsl:value-of select="$word_looparea_exercise"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='websource'"><xsl:value-of select="$word_looparea_websource"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='experiment'"><xsl:value-of select="$word_looparea_experiment"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
+			<xsl:when test="@type='citation'"><xsl:value-of select="$word_looparea_citation"></xsl:value-of></xsl:when>
+			<xsl:otherwise>
+				<xsl:if test="@icontext"><xsl:value-of select="@icontext"></xsl:value-of></xsl:if>
+			</xsl:otherwise> <!-- todo: error msg? -->
+		</xsl:choose>
+	</xsl:variable>
+<!-- 			
+	<xsl:value-of select="$phrase_looparea_start"></xsl:value-of>
+	<xsl:text> </xsl:text> -->
+	<xsl:element name="break">
+		<xsl:attribute name="strength">
+			<xsl:text>strong</xsl:text>
+		</xsl:attribute>
+	</xsl:element>
+	<xsl:value-of select="$looparea_type"></xsl:value-of>
+	<xsl:element name="break">
+		<xsl:attribute name="strength">
+			<xsl:text>strong</xsl:text>
+		</xsl:attribute>
+	</xsl:element>
+	<xsl:apply-templates/>
+	<xsl:element name="break">
+		<xsl:attribute name="strength">
+			<xsl:text>strong</xsl:text>
+		</xsl:attribute>
+	</xsl:element>
+	<!-- <xsl:value-of select="$phrase_looparea_end"></xsl:value-of>
+	<xsl:text> </xsl:text>
+	<xsl:value-of select="$looparea_type"></xsl:value-of>
+	<xsl:element name="break">
+		<xsl:attribute name="strength">
+			<xsl:text>strong</xsl:text>
+		</xsl:attribute>
+	</xsl:element> -->
+	</xsl:template>
+
 	<xsl:template name="math">
 		<xsl:param name="object"></xsl:param>
 		<xsl:text> </xsl:text>

--- a/xsl/terms.xml
+++ b/xsl/terms.xml
@@ -98,8 +98,8 @@
 	<msg name="word_looparea_citation" lang="en">citation</msg>
 	<msg name="word_spoiler_defaulttitle" lang="en">Solution</msg>
 	<msg name="phrase_syntaxhighlight" lang="en">In the online version, there is source code with syntax highlights at this point. </msg>
-	<msg name="phrase_looparea_start" lang="en">Here begins the page area</msg>
-	<msg name="phrase_looparea_end" lang="en">Here ends the page area</msg>
+	<msg name="phrase_looparea_start" lang="en"></msg> <!--Here begins the page area</msg>-->
+	<msg name="phrase_looparea_end" lang="en"></msg> <!--Here ends the page area</msg>-->
 	<msg name="phrase_spoiler_start" lang="en">Here begins hidden content.</msg>
 	<msg name="phrase_spoiler_end" lang="en">Here ends the hidden content.</msg>
 
@@ -164,8 +164,8 @@
 	<msg name="word_looparea_citation" lang="de">Zitat</msg>	
 	<msg name="word_spoiler_defaulttitle" lang="de">Lösung</msg>
 	<msg name="phrase_syntaxhighlight" lang="de">An dieser Stelle befindet sich online Sourcecode mit Syntaxhighlights. </msg>
-	<msg name="phrase_looparea_start" lang="de">Hier beginnt der Seitenbereich</msg>
-	<msg name="phrase_looparea_end" lang="de">Hier endet der Seitenbereich</msg>
+	<msg name="phrase_looparea_start" lang="de"></msg> <!--Hier beginnt der Seitenbereich</msg>-->
+	<msg name="phrase_looparea_end" lang="de"></msg> <!--Hier endet der Seitenbereich</msg>-->
 	<msg name="phrase_spoiler_start" lang="de">Hier beginnt versteckter Inhalt.</msg>
 	<msg name="phrase_spoiler_end" lang="de">Hier endet der versteckte Inhalt.</msg>
 
@@ -228,8 +228,8 @@
 	<msg name="word_looparea_citation" lang="sv">Citat</msg>	
 	<msg name="word_spoiler_defaulttitle" lang="sv">Lösning</msg> 
 	<msg name="phrase_syntaxhighlight" lang="sv">Online finns source code med syntaxhighlights här. </msg>
-	<msg name="phrase_looparea_start" lang="sv">Här börjar sidintervallet</msg>
-	<msg name="phrase_looparea_end" lang="sv">Här slutar sidintervallet</msg>
+	<msg name="phrase_looparea_start" lang="sv"></msg> <!-- Här börjar sidintervallet</msg>-->
+	<msg name="phrase_looparea_end" lang="sv"></msg> <!--slutar sidintervallet</msg>-->
 	<msg name="phrase_spoiler_start" lang="sv">Här börjar doldt innehåll.</msg>
 	<msg name="phrase_spoiler_end" lang="sv">Här slutar dolda innehållet.</msg>
 	

--- a/xsl/terms.xml
+++ b/xsl/terms.xml
@@ -100,6 +100,8 @@
 	<msg name="phrase_syntaxhighlight" lang="en">In the online version, there is source code with syntax highlights at this point. </msg>
 	<msg name="phrase_looparea_start" lang="en">Here begins the page area</msg>
 	<msg name="phrase_looparea_end" lang="en">Here ends the page area</msg>
+	<msg name="phrase_spoiler_start" lang="en">Here begins hidden content.</msg>
+	<msg name="phrase_spoiler_end" lang="en">Here ends the hidden content.</msg>
 
 
 	<msg name="word_chapter" lang="de">Kapitel</msg>
@@ -164,6 +166,8 @@
 	<msg name="phrase_syntaxhighlight" lang="de">An dieser Stelle befindet sich online Sourcecode mit Syntaxhighlights. </msg>
 	<msg name="phrase_looparea_start" lang="de">Hier beginnt der Seitenbereich</msg>
 	<msg name="phrase_looparea_end" lang="de">Hier endet der Seitenbereich</msg>
+	<msg name="phrase_spoiler_start" lang="de">Hier beginnt versteckter Inhalt.</msg>
+	<msg name="phrase_spoiler_end" lang="de">Hier endet der versteckte Inhalt.</msg>
 
 	<msg name="word_chapter" lang="sv">kapitel</msg>
 	<msg name="word_state" lang="sv">Nivå</msg>
@@ -223,9 +227,10 @@
 	<msg name="word_looparea_experiment" lang="sv">Experiment</msg>
 	<msg name="word_looparea_citation" lang="sv">Citat</msg>	
 	<msg name="word_spoiler_defaulttitle" lang="sv">Lösning</msg> 
-	<msg name="phrase_syntaxhighlight" lang="de">Online finns source code med syntaxhighlights här. </msg>
-	<msg name="phrase_looparea_start" lang="de">Här börjar sidintervallet</msg>
-	<msg name="phrase_looparea_end" lang="de">Här slutar sidintervallet</msg>
-
+	<msg name="phrase_syntaxhighlight" lang="sv">Online finns source code med syntaxhighlights här. </msg>
+	<msg name="phrase_looparea_start" lang="sv">Här börjar sidintervallet</msg>
+	<msg name="phrase_looparea_end" lang="sv">Här slutar sidintervallet</msg>
+	<msg name="phrase_spoiler_start" lang="sv">Här börjar doldt innehåll.</msg>
+	<msg name="phrase_spoiler_end" lang="sv">Här slutar dolda innehållet.</msg>
 	
 </terms> 

--- a/xsl/terms.xml
+++ b/xsl/terms.xml
@@ -224,5 +224,9 @@
 <!--	<msg name="word_spoiler_defaulttitle" lang="en">Solution</msg>
 	<msg name="word_spoiler_defaulttitle" lang="de">Lösung</msg>
 	<msg name="word_spoiler_defaulttitle" lang="sv">Lösning</msg> -->
+
+	<msg name="phrase_syntaxhighlight" lang="de">An dieser Stelle befindet sich online Sourcecode mit Syntaxhighlights. </msg>
+	<msg name="phrase_looparea_start" lang="de">Hier beginnt der Seitenbereich</msg>
+	<msg name="phrase_looparea_end" lang="de">Hier endet der Seitenbereich</msg>
 	
 </terms> 

--- a/xsl/terms.xsl
+++ b/xsl/terms.xsl
@@ -124,5 +124,7 @@
 	<xsl:variable name="phrase_syntaxhighlight"  select="functx:get_term_name('phrase_syntaxhighlight')" />
 	<xsl:variable name="phrase_looparea_start"  select="functx:get_term_name('phrase_looparea_start')" />
 	<xsl:variable name="phrase_looparea_end"  select="functx:get_term_name('phrase_looparea_end')" />
+	<xsl:variable name="phrase_spoiler_start"  select="functx:get_term_name('phrase_spoiler_start')" />
+	<xsl:variable name="phrase_spoiler_end"  select="functx:get_term_name('phrase_spoiler_end')" />
 
 </xsl:stylesheet>

--- a/xsl/terms.xsl
+++ b/xsl/terms.xsl
@@ -121,4 +121,8 @@
 	
 	<xsl:variable name="word_spoiler_defaulttitle"  select="functx:get_term_name('word_spoiler_defaulttitle')" />
 
+	<xsl:variable name="phrase_syntaxhighlight"  select="functx:get_term_name('phrase_syntaxhighlight')" />
+	<xsl:variable name="phrase_looparea_start"  select="functx:get_term_name('phrase_looparea_start')" />
+	<xsl:variable name="phrase_looparea_end"  select="functx:get_term_name('phrase_looparea_end')" />
+
 </xsl:stylesheet>


### PR DESCRIPTION
**In extension/Loop einmal composer update ausführen**
Die Extension **SyntaxHighlight_GeSHi** muss installiert sein. 

Syntaxhighlighting funktioniert online und in der PDF. Um Zeilenumbrüche aus Platzgründen in der PDF als solche darzustellen, wird in der PDF standardmäßig die Zeilennummerierung aktiviert. Neue (gewollte) zeilen beginnen so mit einer Zahl.

Der code-Tag, der vorher das Highlighting übernahm, sieht durch Styleveränderungen nun vergleichbar aus, enthält aber kein Highlighting.

Grafiken erhalten nun die responsive-image Klasse.

fix #60 