### PR TITLE
Score extension

### DIFF
--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -388,4 +388,24 @@ class LoopXsl {
 		return $dom;
 	}
 	
+	/**
+	 * Returns image url of musical notes to embed in pdf
+	 */
+	public static function xsl_score( $input, $lang ) {
+		global $wgServer;
+		
+		if( count( $lang ) != 0 ) {
+			$language = $lang[0]->value;
+		} else {
+			$language = 'lilypond';
+		}
+		
+		$parser = new Parser();
+		$html = Score::renderScore( $input[0]->textContent, ['lang' => $language], $parser );
+		preg_match_all( '~<img.*?src=["\']+(.*?)["\']+~', $html, $url );
+		$return = $wgServer . $url[1][0];
+		
+		return $return;
+	}
+
 }

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1775,6 +1775,18 @@
 		<fo:block></fo:block>				
 	</xsl:template>
 	
+	<!-- Loop Score -->
+	<xsl:template match="extension[@extension_name='score']">
+		<fo:block>
+			<xsl:variable name="score" select="."/>
+			<xsl:variable name="lang" select="@lang"/>
+			<xsl:variable name="scoreimg" select="php:function('LoopXsl::xsl_score', $score, $lang)"/>
+
+			<fo:external-graphic scaling="uniform" content-width="scale-to-fit">
+				<xsl:attribute name="src"><xsl:value-of select="$scoreimg"></xsl:value-of></xsl:attribute>
+			</fo:external-graphic>
+		</fo:block>
+	</xsl:template>
 
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1790,7 +1790,7 @@
 
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">
-		<fo:table table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
+		<fo:table keep-together.within-page="always" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
 			<fo:table-column column-number="1" column-width="10mm" />
 			<fo:table-column column-number="2" column-width="6mm" margin-right="-10mm"/>
 			<fo:table-column column-number="3" column-width="146mm"/>


### PR DESCRIPTION
Adds support for score extension.

- ABC-Notation zur Zeit im PDF nicht unterstützt (sitewise jedoch schon). Möglicherweise sind Absätze beim Parsing das Problem, Lilypond funktioniert wie gewohnt.
Es muss die Score Extension installiert sein: https://github.com/wikimedia/mediawiki-extensions-Score.git