### PR TITLE
Fix der ID-Vergabe

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -126,11 +126,6 @@
 		"ParserMakeImageParams":[
 			"LoopHooks::onParserMakeImageParams"
 		],
-		"LinksUpdateConstructed": [
-			"LoopObject::onLinksUpdateConstructed",
-			"LoopLiterature::onLinksUpdateConstructed",
-			"LoopIndex::onLinksUpdateConstructed"
-		],
 		"ArticleDeleteComplete": [
 			"LoopObject::onArticleDeleteComplete",
 			"LoopLiterature::onArticleDeleteComplete",
@@ -148,7 +143,8 @@
 		],
 		"LoopUpdateSavePage": "LoopUpdater::onLoopUpdateSavePage",
 		"EditPage::showEditForm:initial": "LoopWikiEditor::onEditPageShowEditFormInitial",
-		"UploadComplete": "LoopZip::onUploadComplete"
+		"UploadComplete": "LoopZip::onUploadComplete",
+		"PreSaveTransformComplete": "LoopHooks::onPreSaveTransformComplete"
 	},
 	"SpecialPages": {
 		"LoopStructure": "SpecialLoopStructure",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -303,7 +303,6 @@
 	"loopspoiler-error-unknown-spoilertype" : "Der Spoiler <nowiki><loop_spoiler></nowiki> besitzt für den Parameter Bereichstyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Spoiler: XXX",
 
 	"loopexternalcontent-prezi-on": "auf", 
-
 	"namespace-special": "Spezial",
 	"loop-glossary-namespace": "Glossar",
 	"loop-glossary-objectnumber-prefix": "G-",
@@ -312,8 +311,6 @@
 
 	"loopindex": "Index",
 	"loopindex-error-dublicate-id" : "Der Indexbegriff '$3' besitzt keine einzigartige ID ($1). Auf der Seite '$2' ist ein weiterer Begriff mit der ID vorhanden. Bitte ändern Sie die ID, damit auch dieser Begriff indexiert werden kann.",
-	
-	"loop-summary-id": "ID automatisch zu Tag hinzugefügt.",
 
 	"loopwikieditor-section-loop": "LOOP",
 	"loopwikieditor-section-references": "Referenzen",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -288,12 +288,14 @@
 	"loopliterature-error-keyalreadyexists": "Der Zitatschlüssel ist bereits vorhanden. Bitte wählen Sie einen anderen oder überschreiben Sie die Daten.",
 	"loopliterature-error-keyunknown": "Der Zitatschlüssel '''$1''' ist nicht vorhanden. Bitte [[Special:LoopLiteratureEdit| legen Sie den Literatureintrag an]]. ",
 	"loopliterature-error-invalid-export": "Die folgenden Literatureinträge können nicht exportiert werden, da die Zitatschlüssel nicht dem BibTeX-Format entsprechen: ",
+	"loopliterature-error-dublicate-id" : "Die Literaturreferenz '$3' besitzt keine einzigartige ID ($1). Auf der Seite '$2' ist eine weitere Referenz mit der ID vorhanden. Bitte ändern Sie die ID, damit auch diese Referenz im Literaturverzeichnis berücksichtigt werden kann.",
 	
 	"looplegacy-error-unsupported": "Der Tag '''$1''' wird seit $2 nicht mehr unterstützt.",
 	"loopobject-error-unknown-renderoption" : "Die Auszeichnung besitzt für den Parameter Renderoption (render) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-unknown-alignmentoption" : "Die Auszeichnung besitzt für den Parameter Ausrichtung (align) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-unknown-indexoption" : "Die Auszeichnung besitzt für den Parameter Indexierung (index) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-unknown-showcopyrightoption" : "Die Auszeichnung besitzt für den Parameter Copyright anzeigen (show_copyright) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
+	"loopobject-error-dublicate-id" : "Die Objektauszeichnung besitzt keine einzigartige ID ($1). Auf der Seite '$2' ist ein weiteres Objekt mit der ID vorhanden. Bitte ändern Sie die ID und speichern Sie die Seiten neu ab, um eine korrekte Zählung sicherzustellen.",
 	"loopmedia-error-unknown-mediatype" : "Das Medienelement besitzt für den Parameter Medientyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Medienelementen: XXX",
 	"loopreference-error-unknown-titleoption" : "Die Referenz besitzt für den Parameter Titelanzeige (title) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Referenzen: XXX",
 	"loopreference-error-unknown-refid" : "Die Referenz bezieht sich auf eine unbekannte ID: '''$1'''.\nDokumentation zu Referenzen: XXX",
@@ -309,6 +311,8 @@
 	"loop-glossary-empty": "Es ist noch kein Glossareintrag vorhanden. Erstellen Sie einen neuen, indem Sie eine Seite wie ''[[Glossar:Begriff]]'' anlegen.",
 
 	"loopindex": "Index",
+	"loopindex-error-dublicate-id" : "Der Indexbegriff '$3' besitzt keine einzigartige ID ($1). Auf der Seite '$2' ist ein weiterer Begriff mit der ID vorhanden. Bitte ändern Sie die ID, damit auch dieser Begriff indexiert werden kann.",
+	
 	"loop-summary-id": "ID automatisch zu Tag hinzugefügt.",
 
 	"loopwikieditor-section-loop": "LOOP",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -288,12 +288,14 @@
 	"loopliterature-error-keyalreadyexists": "The literature key exists already. Please choose a different one or overwrite the data.",
 	"loopliterature-error-keyunknown": "The literature key '''$1''' does not exist. Please [[Special:LoopLiteratureEdit| create it]]. ",
 	"loopliterature-error-invalid-export": "The following literature entries cannot be exported, as the key does not match BibTeX format: ",
-	
+	"loopliterature-error-dublicate-id" : "The literature reference '$3' does not have a unique ID ($1). On page '$2' is another reference with that same ID. Please change the ID so the reference can be taken into account in bibliography.",
+
 	"looplegacy-error-unsupported": "The tag '''$1''' is deprecated since $2.",
 	"loopobject-error-unknown-renderoption" : "The object's render option (render) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopobject-error-unknown-alignmentoption" : "The object's alignment option (align) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopobject-error-unknown-indexingoption" : "The object's indexing option (index) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
 	"loopobject-error-unknown-showcopyrightoption" : "The object's show copyright option (show_copyright) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
+	"loopobject-error-dublicate-id" : "The object's ID is not unique ($1). On page '$2' is another object with that same ID. Please change the ID and save the pages again so the numbering will be correct.",
 	"loopmedia-error-unknown-mediatype" : "The media's type option (type) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopreference-error-unknown-titleoption" : "The reference's show title option (title) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopreference-error-unknown-refid" : "The reference's given ID is unknown: '''$1'''.",
@@ -308,7 +310,7 @@
 	"loop-glossary-empty": "The glossary is still empty. Add an entry by creating a page like ''[[Glossary:Term]]''.",
 	
 	"loopindex": "Index",
-	"loop-summary-id": "ID added automatically.",
+	"loopindex-error-dublicate-id" : "The indexed term '$3' does not have a unique ID ($1). On page '$2' is another term with that same ID. Please change the ID so the term can be properly indexed.",
 
 	"loopwikieditor-section-loop": "LOOP",
 	"loopwikieditor-section-references": "References",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -288,12 +288,14 @@
 	"loopliterature-error-keyalreadyexists": "Error message for literature: key exists already",
 	"loopliterature-error-keyunknown": "Error message for literature: key unknown",
 	"loopliterature-error-invalid-export": "Error message for literature: key invalid for export",
+	"loopliterature-error-dublicate-id" : "Error Message rendered when Object has a dublicate ID: $1 -> given ID; $2 -> Page where the original ID is used; $3 -> Key/Term of the original object",
 	
 	"looplegacy-error-unsupported": "The tag '''$1''' is deprecated since $2.",
 	"loopobject-error-unknown-renderoption" : "Error Message rendered when render option is unknown\n\nParameters:\n* $1 - render option\n* $2 supported render options",
 	"loopobject-error-unknown-alignmentoption" : "Error Message rendered when align option is unknown\n\nParameters:\n* $1 - align option\n* $2 supported align options",
 	"loopobject-error-unknown-indexingoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - indexing option\n* $2 supported index options",
 	"loopobject-error-unknown-showcopyrightoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - show_copyright option\n* $2 supported show_copyright options",
+	"loopobject-error-dublicate-id" : "Error Message rendered when Object has a dublicate ID: $1 -> given ID; $2 -> Page where the original ID is used",
 	"loopmedia-error-unknown-mediatype" : "Error Message rendered when type option is unknown\n\nParameters:\n* $1 - type option\n* $2 supported type options",
 	"loopreference-error-unknown-titleoption" : "Error Message rendered when title option is unknown\n\nParameters:\n* $1 - title option\n* $2 supported title options",
 	"loopreference-error-unknown-refid" : "Error Message rendered when id option is unknown.\n\nParameters:\n* $1 - given id",
@@ -307,8 +309,8 @@
 	"loopglossary": "Title displayed for list glossary",
 	"loop-glossary-empty": "Shown message on Glossary special page when there is no glossary entry. ",
 
-	"loopindex": "page title for Special:LoopIndex",
-	"loop-summary-id": "Message for summary after automatic adding of ids",
+	"loopindex": "page title for Special:LoopIndex",	
+	"loopindex-error-dublicate-id" : "Error Message rendered when Object has a dublicate ID: $1 -> given ID; $2 -> Page where the original ID is used; $3 -> Key/Term of the original object",
 
 	"loopwikieditor-section-loop": "Wikieditor section: LOOP functions",
 	"loopwikieditor-section-references": "Wikieditor section: LOOP References",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -288,12 +288,14 @@
 	"loopliterature-error-keyalreadyexists": "Citatnyckeln finns redan. Vänligen välj ett annat eller skriv över uppgifter.",
 	"loopliterature-error-keyunknown": "Citatnyckeln '''$1''' finns inte. Vänligen [[Special:LoopLiteratureEdit| lägg till den]]. ",
 	"loopliterature-error-invalid-export": "Dem här citatnycklar överenstämmar inte med BibTeX-formatet och kan inte exporteras: ",
-	
+	"loopliterature-error-dublicate-id" : "Litteraturreferensen '$3' besitter ingen unik ID ($1). På sidan '$2' finns det en annan litteraturreferens med den här ID. Vänligen byt ID:n, så referensen visas korrekt i bibliografin.",
+
 	"looplegacy-error-unsupported": "Taggen '''$1''' har tagits bort i $2",
 	"loopobject-error-unknown-renderoption" : "Värdet av parametern (render) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-unknown-alignmentoption" : "Värdet av parametern (align) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-unknown-indexingoption" : "Värdet av parametern (index) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-unknown-showcopyrightoption" : "Värdet av parametern (show_copyright) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
+	"loopobject-error-dublicate-id" : "Objektet besitter ingen unik ID ($1). På sidan '$2' finns det ett annat objekt med den här ID. Vänligen byt ID:n och spara sidor igen, så objektet kan numereras korrekt.",
 	"loopmedia-error-unknown-mediatype" : "Värdet av parametern (type) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopreference-error-unknown-titleoption" : "Värdet av parametern (title) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopreference-error-unknown-refid" : "Referensens angivit ID är okänd: '''$1'''.",
@@ -308,7 +310,7 @@
 	"loop-glossary-empty": "Ordlistan är fortfarande tom. Lägg till en post genom att skapa en sida som ''[[Glossary:Ord]]''.",
 	
 	"loopindex": "Index",
-	"loop-summary-id": "ID lades till automatiskt.",
+	"loopindex-error-dublicate-id" : "Index termen '$3' besitter ingen unik ID ($1). På sidan '$2' finns det en annan index term med den här ID. Vänligen byt ID:n, så termen kan indexeras.",
 
 	"loopwikieditor-section-loop": "LOOP",
 	"loopwikieditor-section-references": "Referenser",

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -144,4 +144,18 @@ class LoopHooks {
 		return true;
 	}	
 
+	/**
+	 * Custom hook called after after pre save transforming
+	 * @param String &$text
+	 * @param Title $title
+	 * @param User $user
+	 */
+	public static function onPreSaveTransformComplete( &$text, $title, $user ) {
+		
+		$text = Loop::setReferenceIds( $text );
+		
+		return true;
+
+	}
+
 }

--- a/includes/LoopIndex.php
+++ b/includes/LoopIndex.php
@@ -22,13 +22,27 @@ class LoopIndex {
     }	
     
 	static function renderLoopIndex( $input, array $args, Parser $parser, PPFrame $frame ) {
-        
-       # dd($args);
-        $id = "";
+
+		global $wgOut;
+		$html = '';
         if ( isset ( $args["id"] ) ) {
-            $id = "id='" . $args["id"] . "' ";
-        }
-        $html = "<span class='loop_index_anchor' $id></span>";
+			$id = $args["id"];
+            $htmlid = "id='" . $id . "' ";
+		}
+		
+		$item = self::getIndexItem( $id );
+		if ( $item ) {
+			$articleId = $wgOut->getTitle()->getArticleID();
+			# check if a dublicate id has been used
+			if ( $input != $item->li_index || $articleId != $item->li_pageid ) { 
+				$otherTitle = Title::newFromId( $item->li_pageid );
+				$e = new LoopException( wfMessage( 'loopindex-error-dublicate-id', $id, $otherTitle->mTextform, $item->li_index ) );
+				$parser->addTrackingCategory( 'loop-tracking-category-error' );
+				$html .= $e . "\n";
+			}
+		}
+        $htmlid = "";
+        $html .= "<span class='loop_index_anchor' $htmlid></span>";
         return $html;
     }
 
@@ -69,6 +83,33 @@ class LoopIndex {
         SpecialPurgeCache::purge();
         
         return true;
+
+	}
+	
+    /**
+	 * Returns index item
+	 * @return bool true
+	 */
+	public static function getIndexItem( $refId ) {
+		$dbr = wfGetDB( DB_REPLICA );
+		$res = $dbr->select(
+			'loop_index',
+			array(
+				'li_refid',
+                'li_index',
+                'li_pageid'
+			),
+			array(
+				'li_refid = "' . $refId .'"'
+			),
+			__METHOD__
+		);
+		
+        foreach( $res as $row ) {
+			return $row;
+		}
+        
+        return false;
 
     }
     
@@ -176,18 +217,12 @@ class LoopIndex {
 	        $stableRevId = $fwp->getStable();
 	        
 	        if ( $latestRevId == $stableRevId || $stableRevId == null ) {
-	            # In Loop Upgrade process, use user LOOP_SYSTEM for edits and review.
-	            $user = null;
-	            $systemUser = User::newSystemUser( 'LOOP_SYSTEM', [ 'steal' => true, 'create'=> false, 'validate' => true ] );
-	            if ( $systemUser->getId() == $userId ) {
-	                $user = $systemUser;
-	            }
-	            
-	            self::handleIndexItems( $wikiPage, $title, $content, $user );
+	            self::handleIndexItems( $wikiPage, $title, $content->getText() );
 	        }
 	    }
 	    return true;
 	}
+
 	/**
 	 * Custom hook called after stabilization changes of pages in FlaggableWikiPage->clearStableVersion()
 	 * @param Title $title
@@ -210,43 +245,31 @@ class LoopIndex {
 	}
 	
 	/**
-	 * Checks revision status after saving content and starts db writing function in case of stable revision.
-	 * Attached to LinksUpdateConstructed hook.
-	 * @param LinksUpdate $linksUpdate
-	 */
-	public static function onLinksUpdateConstructed( $linksUpdate ) { 
-		$title = $linksUpdate->getTitle();
-		$wikiPage = WikiPage::factory( $title );
-		$latestRevId = $title->getLatestRevID();
-		if ( isset($title->flaggedRevsArticle) ) {
-			$stableRevId = $title->flaggedRevsArticle;
-			$stableRevId = $stableRevId->getStable();
-
-			if ( $latestRevId == $stableRevId || $stableRevId == null ) {
-				self::handleIndexItems( $wikiPage, $title );
-			}
-		}
-
-		return true;
-	}
-	
-	/**
 	 * Adds index items to db. Called by onLinksUpdateConstructed and onAfterStabilizeChange (custom Hook)
 	 * @param WikiPage $wikiPage
 	 * @param Title $title
-	 * @param Content $content
-	 * @param User $user
+	 * @param String $contentText
 	 */
-	public static function handleIndexItems( &$wikiPage, $title, $content = null, $user = null ) {
+	public static function handleIndexItems( &$wikiPage, $title, $contentText = null ) {
 		
-		if ($content == null) {
-			$content = $wikiPage->getContent();
+		$content = $wikiPage->getContent();
+		if ($contentText == null) {
+			$contentText = $content->getText();
 		}
+
 		if ( $title->getNamespace() == NS_MAIN || $title->getNamespace() == NS_GLOSSARY ) {
-			$loopIndex = new LoopIndex();
-			self::removeAllPageItemsFromDb ( $title->getArticleID() );
-			$contentText = ContentHandler::getContentText( $content );
+			
 			$parser = new Parser();
+			$loopIndex = new LoopIndex();
+			$fwp = new FlaggableWikiPage ( $title );
+			$stableRevId = $fwp->getStable();
+			$latestRevId = $title->getLatestRevID();
+			$stable = false;
+			if ( $stableRevId == $latestRevId ) {
+				$stable = true;
+				# on edit, delete all objects of that page from db. 
+				self::removeAllPageItemsFromDb ( $title->getArticleID() );
+			}
 
 			# check if loop_index is in page content
 			$has_reference = false;
@@ -264,6 +287,7 @@ class LoopIndex {
 				$loopStructure->loadStructureItems();
 				foreach ( $object_tags as $object ) {
 					if ( ! in_array( strtolower($object[0]), $forbiddenTags ) ) { #exclude loop-tags that are in code or nowiki tags
+						$valid = true;
 						$tmpLoopIndex = new LoopIndex();
 						$tmpLoopIndex->pageId = $title->getArticleID();
 						$tmpLoopIndex->index = $object[1];
@@ -272,18 +296,13 @@ class LoopIndex {
 							if ( $tmpLoopIndex->checkDublicates( $object[2]["id"] ) ) {
 								$tmpLoopIndex->refId = $object[2]["id"];
 							} else {
-								# dublicate id must be replaced
-								$newRef = uniqid();
-								$newContentText = preg_replace('/(id="'. $object[2]["id"].'")/', 'id="'. $newRef.'"'  , $newContentText, 1 );
-								$tmpLoopIndex->refId = $newRef; 
+								# dublicate id!
+								$valid = false;
 							}
-						} else {
-							# create new id
-							$newRef = uniqid();
-							$newContentText = LoopObject::setReferenceId( $newContentText, $newRef, 'loop_index' ); 
-							$tmpLoopIndex->refId = $newRef; 
+						} 
+						if ( $valid && $stable ) {
+							$tmpLoopIndex->addToDatabase();
 						}
-						$tmpLoopIndex->addToDatabase();
 					}
 				}
 				$lsi = LoopStructureItem::newFromIds ( $title->getArticleID() );
@@ -294,19 +313,11 @@ class LoopIndex {
 					LoopGlossary::updateGlossaryPageTouched();
 				}
 				if ( $contentText !== $newContentText ) {
-					
-					$fwp = new FlaggableWikiPage ( $title );
-					$stableRev = $fwp->getStable();
-					if ( $stableRev == 0 ) {
-						$stableRev = $wikiPage->getRevision()->getId();
-					} 
-
-					$summary = wfMessage("loop-summary-id")->text();
-					$content = $content->getContentHandler()->unserializeContent( $newContentText );
-					$wikiPage->doEditContent ( $content, $summary, EDIT_UPDATE, $stableRev, $user );
+					return $newContentText;
 				}	
 			}
 		}
+		return $contentText;
 	}
 
 }

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -163,7 +163,7 @@ class LoopObject {
 	 * @return string
 	 */
 	public function render() {
-		global $wgLoopObjectNumbering, $wgOut;
+		global $wgLoopObjectNumbering;
 
 		LoggerFactory::getInstance( 'LoopObject' )->debug( 'Start rendering' );
 
@@ -180,15 +180,19 @@ class LoopObject {
 			
 			$html .= 'id="' . $this->getId() . '" ';
 			$object = LoopObjectIndex::getObjectData( $this->getId() );
-			$articleId = $wgOut->getTitle()->getArticleID();
-
+			$articleId = $this->getParser()->getTitle()->getArticleID();
+		#dd( $this->getTitle() , $object["title"] , $articleId , $object["articleId"] , $this->getTag() , $object["index"], $object );
 			#if there are hints for this element has a dublicate id, don't render the number and add an error
 			if ( $this->getTitle() != $object["title"] || $articleId != $object["articleId"] || $this->getTag() != $object["index"] ) { 
 				$otherTitle = Title::newFromId( $object["articleId"] );
 				if (! isset( $this->error ) ){
 					$this->error = "";
 				} 
-				$e = new LoopException( wfMessage( 'loopobject-error-dublicate-id', $this->getId(), $otherTitle->mTextform ) );
+				$textform = "-";
+				if ( is_object( $otherTitle ) ) {
+					$textform = $otherTitle->mTextform;
+				}
+				$e = new LoopException( wfMessage( 'loopobject-error-dublicate-id', $this->getId(), $textform ) );
 				$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 				$this->error .= $e . "\n";
 				$showNumbering = false;
@@ -930,6 +934,13 @@ class LoopObject {
 							}
 							if ( isset( $object[2]["title"] ) ) {
 								$tmpLoopObjectIndex->itemTitle = $object[2]["title"];
+							} else {
+								$title_tags = array ();
+								$parser->extractTagsAndParams( ["loop_title", "loop_figure_title"], $object[1], $title_tags );
+								foreach( $title_tags as $tag ) {
+									$tmpLoopObjectIndex->itemTitle = $tag[1];
+									break;
+								}
 							}
 							if ( isset( $object[2]["description"] ) ) {
 								$tmpLoopObjectIndex->itemDescription = $object[2]["description"];

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -181,7 +181,7 @@ class LoopObject {
 			$html .= 'id="' . $this->getId() . '" ';
 			$object = LoopObjectIndex::getObjectData( $this->getId() );
 			$articleId = $this->getParser()->getTitle()->getArticleID();
-		#dd( $this->getTitle() , $object["title"] , $articleId , $object["articleId"] , $this->getTag() , $object["index"], $object );
+			
 			#if there are hints for this element has a dublicate id, don't render the number and add an error
 			if ( $this->getTitle() != $object["title"] || $articleId != $object["articleId"] || $this->getTag() != $object["index"] ) { 
 				$otherTitle = Title::newFromId( $object["articleId"] );

--- a/includes/LoopToc.php
+++ b/includes/LoopToc.php
@@ -17,10 +17,8 @@ class LoopToc extends LoopStructure {
     }
 
 	static function renderLoopToc( $input, array $args, Parser $parser, PPFrame $frame ) {
-		
-        global $wgOut;
-        
-		$result = self::outputLoopToc( $wgOut->getTitle()->mArticleID, "html" );
+	
+		$result = self::outputLoopToc( $parser->getTitle()->mArticleID, "html" );
 
         $return  = '<div class="looptoc">';
         $return .= $result;

--- a/includes/LoopUpdater.php
+++ b/includes/LoopUpdater.php
@@ -145,18 +145,20 @@ class LoopUpdater {
 		$systemUser = User::newSystemUser( 'LOOP_SYSTEM', [ 'steal' => true, 'create'=> true, 'validate' => true ] );
 		$systemUser->addGroup("sysop");
 		
+		$wikiPage->doEditContent( $wikiPage->getRevision()->getContent(), 'LOOP2 Upgrade', EDIT_UPDATE, false, $systemUser );
+		
 		if ( isset( $fwp ) ) {
 			$stableRevId = $fwp->getStable();
 
 			if ( $latestRevId == $stableRevId || $stableRevId == null ) { # page is stable or does not have any stable version
-				$content = null;
 				$contentText = null;
 			} else {
 				$revision = $wikiPage->getRevision();
-				$content = $revision->getContent();
 				$contentText = $revision->getContent()->getText();
 			}
-			LoopObject::doIndexLoopObjects( $wikiPage, $title, $content, $systemUser );
+			
+
+			LoopObject::handleObjectItems( $wikiPage, $title, $contentText );
 			self::migrateLiterature( $wikiPage, $title, $contentText, $systemUser );
 			self::migrateLoopZip( $wikiPage, $title, $contentText, $systemUser );
 		}


### PR DESCRIPTION
fix #151 
IDs werden jetzt in einem neuen Hook gesetzt, getrennt von Objekten: onPreSaveTransformComplete
In den Objektfunktionen wird nur noch in die DB gespeichert, wenn es die ID noch nicht gab. Dazu gibt es neue Fehlermeldungen. Betroffen sind die loop_object Tags, cite und loop_index.

- Der Updateprozess funktioniert wieder wie vorher.
- doppelte IDs sind in PDFs kein Problem mehr.