### PR TITLE
PDF seitenweise testen

### DIFF
--- a/Loop.i18n.alias.php
+++ b/Loop.i18n.alias.php
@@ -27,7 +27,8 @@ $specialPageAliases['en'] = array(
 	'LoopGlossary' => array( 'Glossary' ),
 	'LoopIndex' => array( 'Index' ),
 	'LoopTerminology' => array( 'List of abbreviations' ),
-	'LoopTerminologyEdit' => array( 'Edit list of abbreviations' )
+	'LoopTerminologyEdit' => array( 'Edit list of abbreviations' ),
+	'LoopExportPdfTest' => array( 'Test PDF page by page' )
 	);
 
 $specialPageAliases['de'] = array(
@@ -49,7 +50,8 @@ $specialPageAliases['de'] = array(
 	'LoopGlossary' => array( 'Glossar', 'Glossary' ),
 	'LoopIndex' => array( 'Index' ),
 	'LoopTerminology' => array( 'Abkürzungsverzeichnis' ),
-	'LoopTerminologyEdit' => array( 'Abkürzungsverzeichnis bearbeiten' )
+	'LoopTerminologyEdit' => array( 'Abkürzungsverzeichnis bearbeiten' ),
+	'LoopExportPdfTest' => array( 'PDF seitenweise testen' )
 	);
 	
 $specialPageAliases['sv'] = array(
@@ -71,7 +73,8 @@ $specialPageAliases['sv'] = array(
 	'LoopGlossary' => array( 'Glossary', 'Ordlista' ),
 	'LoopIndex' => array( 'Index' ),
 	'LoopTerminology' => array( 'Förkortningar' ),
-	'LoopTerminologyEdit' => array( 'Regidera förkortningar' )
+	'LoopTerminologyEdit' => array( 'Regidera förkortningar' ),
+	'LoopExportPdfTest' => array( 'Testa PDF sida för sida' )
 	);
 
 

--- a/extension.json
+++ b/extension.json
@@ -97,7 +97,8 @@
 		"LoopTerminology": "includes/LoopTerminology.php",
 		"SpecialLoopTerminology": "includes/LoopTerminology.php",
 		"SpecialLoopTerminologyEdit": "includes/LoopTerminology.php",
-		"LoopScreenshot": "includes/LoopScreenshot.php"
+		"LoopScreenshot": "includes/LoopScreenshot.php",
+		"SpecialLoopExportPdfTest": "includes/LoopPdf.php"
 	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates":[
@@ -179,7 +180,8 @@
 		"LoopGlossary": "SpecialLoopGlossary",
 		"LoopIndex": "SpecialLoopIndex",
 		"LoopTerminology": "SpecialLoopTerminology",
-		"LoopTerminologyEdit": "SpecialLoopTerminologyEdit"
+		"LoopTerminologyEdit": "SpecialLoopTerminologyEdit",
+		"LoopExportPdfTest": "SpecialLoopExportPdfTest"
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "",

--- a/extension.json
+++ b/extension.json
@@ -326,7 +326,8 @@
 			"createpage": false,
 			"writeapi": false,
 			"loop-view-special-pages": false,
-			"loop-edit-literature": false
+			"loop-edit-literature": false,
+			"loop-pdf-test": false
 		},
 		"user" : {
 			"read": true
@@ -368,7 +369,8 @@
 			"editsitecss": true,
 			"editsitejs": true,
 			"editinterface": true,
-			"writeapi": true
+			"writeapi": true,
+			"loop-pdf-test": true
 		},
 		"author": {
 			"loop-toc-edit": true,
@@ -405,7 +407,8 @@
 			"editsitecss": true,
 			"editsitejs": true,
 			"editinterface": true,
-			"writeapi": true
+			"writeapi": true,
+			"loop-pdf-test": true
 		},
 		"teacher_approve": {
 			"loop-toc-edit": true,
@@ -442,7 +445,8 @@
 			"editsitecss": true,
 			"editsitejs": true,
 			"editinterface": true,
-			"writeapi": true
+			"writeapi": true,
+			"loop-pdf-test": true
 		},
 		"teacher_edit": {
 			"loop-toc-edit": true,
@@ -473,7 +477,8 @@
 			"protect": true,
 			"loop-view-special-pages": true,
 			"loop-edit-literature": true,
-			"writeapi": true
+			"writeapi": true,
+			"loop-pdf-test": true
 		},
 		"teacher_no_edit": {
 			"loop-export-pdf": true,
@@ -507,7 +512,8 @@
 			"browsearchive": true,
 			"loop-view-special-pages": true,
 			"loop-edit-literature": true,
-			"writeapi": true
+			"writeapi": true,
+			"loop-pdf-test": true
 		},
 		"student_no_edit": {
 			"loop-export-pdf": true,

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -84,7 +84,7 @@
 	"loopexport-audio-intro-url": "Das Loop ist online unter $1 zu finden. ",
 	"loopexport-audio-intro-date": "Es ist auf dem Stand von $1.",
 	"loopexportpdftest": "PDF seitenweise testen",
-	"loopexport-pdf-test-success": "Es ist kein Fehler aufgetreten! Funktioniert die PDF dennoch nicht, [[Special:PurgeCache|löschen Sie den Cache]] und/oder kontaktieren Sie die/den AdministratorIn",
+	"loopexport-pdf-test-success": "Alle seiten funktionieren korrekt! Funktioniert die PDF dennoch nicht, [[Special:PurgeCache|löschen Sie den Cache]] und/oder kontaktieren Sie die/den AdministratorIn",
 	"loopexport-pdf-test-failure": "Auf der Seite [[$1]] ist ein Fehler aufgetreten. Sie können sich den Fehlerbericht unten ansehen.",
 	"loopexport-pdf-test-notice": "In der Trackingkategorie für $1 sind Seiten gelistet, die Fehler beinhalten. Sie können sich diese im Bearbeitungsmodus auf den jeweiligen Seiten ansehen.",
 

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -84,6 +84,9 @@
 	"loopexport-audio-intro-url": "Das Loop ist online unter $1 zu finden. ",
 	"loopexport-audio-intro-date": "Es ist auf dem Stand von $1.",
 	"loopexportpdftest": "PDF seitenweise testen",
+	"loopexport-pdf-test-success": "Es ist kein Fehler aufgetreten! Funktioniert die PDF dennoch nicht, [[Special:PurgeCache|löschen Sie den Cache]] und/oder kontaktieren Sie die/den AdministratorIn",
+	"loopexport-pdf-test-failure": "Auf der Seite [[$1]] ist ein Fehler aufgetreten. Sie können sich den Fehlerbericht unten ansehen.",
+	"loopexport-pdf-test-notice": "In der [[Kategorie:$1|Trackingkategorie für LOOP-Fehler]] sind Seiten gelistet, die Fehler beinhalten. Sie können sich diese im Bearbeitungsmodus auf den jeweiligen Seiten ansehen.",
 
 	"right-loop-toc-edit": "Inhaltsverzeichnis bearbeiten",
 	"right-loop-export-pdf": "Export LOOP als PDF",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -86,7 +86,7 @@
 	"loopexportpdftest": "PDF seitenweise testen",
 	"loopexport-pdf-test-success": "Es ist kein Fehler aufgetreten! Funktioniert die PDF dennoch nicht, [[Special:PurgeCache|löschen Sie den Cache]] und/oder kontaktieren Sie die/den AdministratorIn",
 	"loopexport-pdf-test-failure": "Auf der Seite [[$1]] ist ein Fehler aufgetreten. Sie können sich den Fehlerbericht unten ansehen.",
-	"loopexport-pdf-test-notice": "In der [[Kategorie:$1|Trackingkategorie für LOOP-Fehler]] sind Seiten gelistet, die Fehler beinhalten. Sie können sich diese im Bearbeitungsmodus auf den jeweiligen Seiten ansehen.",
+	"loopexport-pdf-test-notice": "In der Trackingkategorie für $1 sind Seiten gelistet, die Fehler beinhalten. Sie können sich diese im Bearbeitungsmodus auf den jeweiligen Seiten ansehen.",
 
 	"right-loop-toc-edit": "Inhaltsverzeichnis bearbeiten",
 	"right-loop-export-pdf": "Export LOOP als PDF",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -83,6 +83,7 @@
 	"loopexport-audio-intro-title": "Dies ist das Hörbuch des Loops: $1",
 	"loopexport-audio-intro-url": "Das Loop ist online unter $1 zu finden. ",
 	"loopexport-audio-intro-date": "Es ist auf dem Stand von $1.",
+	"loopexportpdftest": "PDF seitenweise testen",
 
 	"right-loop-toc-edit": "Inhaltsverzeichnis bearbeiten",
 	"right-loop-export-pdf": "Export LOOP als PDF",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -83,6 +83,9 @@
 	"loopexport-audio-intro-title": "This is the audiobook of: $1",
 	"loopexport-audio-intro-url": "You can find the loop online at $1. ",
 	"loopexport-audio-intro-date": "It is at the level of $1",
+	"loopexport-pdf-test-success": "All pages were loaded successfully! If the PDF still doesn't work, [[Special:PurgeCache|delete the caches]] or contact your administrator.",
+	"loopexport-pdf-test-failure": "An error occurred on page [[$1]]. You can look at the error log at the end of this page.",
+	"loopexport-pdf-test-notice": "In the tracking category for $1 are pages listed that contain errors. Look at these pages in edit mode to find the sources.",
 
 	"right-loop-toc-edit": "Edit toc",
 	"right-loop-export-pdf": "Export LOOP as PDF",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -83,6 +83,9 @@
 	"loopexport-audio-intro-title": "Audiobook introduction, $1 is the loop title",
 	"loopexport-audio-intro-url": "Audiobook introduction about where to find loop, $1 is url to loop ",
 	"loopexport-audio-intro-date": "Audiobook introduction about it's state, $1 is the last-changed date of downloaded files",
+	"loopexport-pdf-test-success": "Success message after testing pdf per-page. In case the pdf still does not work, a link to Special:PurgeCache should be added.",
+	"loopexport-pdf-test-failure": "Failure message after testing pdf per-page.",
+	"loopexport-pdf-test-notice": "Notice about pages in loop error tracking category. After testing pdf per-page.",
 
 	"right-loop-toc-edit": "Right to edit toc",
 	"right-loop-export-pdf": "Right to export LOOP as PDF",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -83,6 +83,9 @@
 	"loopexport-audio-intro-title": "Detta är Ljudboken från Loop: $1",
 	"loopexport-audio-intro-url": "Detta Loop finns online på $1. ",
 	"loopexport-audio-intro-date": "Nivå: $1",
+	"loopexport-pdf-test-success": "Inga fel hittades! Om PDF funker inte, [[Special:PurgeCache|rensa cachen]] eller kontaktera administratorn.",
+	"loopexport-pdf-test-failure": "På sidan [[$1]] uppstod ett fel. Du kan läsa loggen nedan.",
+	"loopexport-pdf-test-notice": "I trackingkategoriet för $1 finns sidor med fel. Titta på dem i regideringsmodus.",
 
 	"right-loop-toc-edit": "Regidera innehåll",
 	"right-loop-export-pdf": "Export LOOP som PDF",

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -83,7 +83,7 @@ class LoopHooks {
 				'Mostlinkedtemplates', 'Deadendpages', 'JavaScriptTest', 'Userrights', 'Import', 'Ancientpages', 'Uncategorizedcategories', 'Activeusers', 
 				'MergeHistory', 'Randompage', 'Protectedpages', 'Wantedfiles', 'Listgrouprights', 'EditWatchlist', 'Blockme', 'FileDuplicateSearch', 
 				'Withoutinterwiki', 'Randomredirect', 'BlockList', 'Popularpages', 'Emailuser', 'Booksources', 'Upload', 'Confirmemail', 'Watchlist', 
-				'MIMEsearch', 'Allpages', 'Fewestrevisions', 'Unblock', 'ComparePages', 'Uncategorizedimages', 'Mostinterwikis', 
+				'MIMEsearch', 'Allpages', 'Fewestrevisions', 'Unblock', 'ComparePages', 'Uncategorizedimages', 'Mostinterwikis', 'LoopExportPdfTest',
 				'Categories', 'Statistics', 'Version', 'UploadStash', 'Undelete', 'Whatlinkshere', 'Lockdb', 'Lonelypages', 'Mostimages', 
 				'Unwatchedpages', 'Shortpages', 'Protectedtitles', 'Revisiondelete', 'Newpages', 'Unusedtemplates', 'Allmessages', 'CachedPage', 
 				'Filepath', 'Wantedpages', 'LinkSearch', 'Prefixindex', 'BrokenRedirects', 'Mostlinked', 'Tags', 'LoopStructureEdit', 'LoopSettings', 

--- a/includes/LoopObjectIndex.php
+++ b/includes/LoopObjectIndex.php
@@ -139,13 +139,16 @@ class LoopObjectIndex {
                 );
                 
                 $lsi = LoopStructureItem::newFromIds($row->loi_pageid);
-                if ( $lsi ) {
-                    $pageData = array( "structure", $lsi, $loopStructure );
-                    $numberText = LoopObject::getObjectNumberingOutput( $row->loi_refid, $pageData, $previousObjects[ $row->loi_pageid ], $objectData );
-                } elseif ( isset ( $previousObjects[ $row->loi_pageid ] ) ) {
-					$pageData = array( "glossary", $row->loi_pageid );
-					$numberText = LoopObject::getObjectNumberingOutput( $row->loi_refid, $pageData, $previousObjects[ $row->loi_pageid ], $objectData );
+                if ( in_array( $row->loi_pageid, $previousObjects ) ) {
+                    if ( $lsi ) {
+                        $pageData = array( "structure", $lsi, $loopStructure );
+                        $numberText = LoopObject::getObjectNumberingOutput( $row->loi_refid, $pageData, $previousObjects[ $row->loi_pageid ], $objectData );
+                    } elseif ( isset ( $previousObjects[ $row->loi_pageid ] ) ) {
+                        $pageData = array( "glossary", $row->loi_pageid );
+                        $numberText = LoopObject::getObjectNumberingOutput( $row->loi_refid, $pageData, $previousObjects[ $row->loi_pageid ], $objectData );
+                    }
                 }
+                
             }
         
             $objects[$row->loi_refid] = array(

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -171,7 +171,12 @@ class SpecialLoopExportPdfTest extends SpecialPage {
 			$trackingCategoryItems = $trackingCategory->getMembers();
 	
 			if ( !empty( $trackingCategoryItems ) ) {
-				$out->addHtml( '<div class="alert alert-warning" role="alert">' . $this->msg( 'loopexport-pdf-test-notice', $this->msg("loop-tracking-category-error")->text() ) . $this->msg("loop-tracking-category-error")->text(). '</div>' );
+				$link = $linkRenderer->makelink(
+					Title::newFromText( $this->msg( "loop-tracking-category-error" )->text(), NS_CATEGORY ), 
+					new HtmlArmor( $this->msg( "loop-tracking-category-error" )->text() ),
+					array('target' => '_blank' )
+					);
+				$out->addHtml( '<div class="alert alert-warning" role="alert">' . $this->msg( 'loopexport-pdf-test-notice', $link )->text() . '</div>' . $link . "<br>" );
 			}
 
 		} else {

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -26,7 +26,6 @@ class LoopPdf {
 		$errors = '';
 		
 		$xmlfo = self::transformToXmlfo( $wiki_xml );
-		
 		$pdf = self::makePdfRequest( $xmlfo["xmlfo"] );
 		
 		if ( !empty($errors) ) {
@@ -34,7 +33,7 @@ class LoopPdf {
 		}
 		if ( strpos( $pdf, "%PDF") !== 0 ) {
 			#es werden keine leeren/fehlerhaften PDFs mehr heruntergeladen, solange das hier aktiv ist.
-			var_dump( "Error!", $pdf, $xmlfo, $wiki_xml );exit; #dd ist zu JS-ressourcenintensiv
+			var_dump( "Error! Anstatt eine leere PDF auszugeben, gibt es jetzt den content hier. #debug", $pdf, $xmlfo, $wiki_xml );exit; #dd ist zu JS-ressourcenintensiv
 		}
 		#var_dump( "Debug! PDF funktioniert eigentlich. ", $xmlfo, $wiki_xml );exit;
 		return $pdf;

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -1,27 +1,46 @@
 <?php 
+/**
+ * @description Exports LOOP to PDF and test PDF side 
+ * @ingroup Extensions
+ * @author Marc Vorreiter @vorreiter <marc.vorreiter@th-luebeck.de>
+ * @author Dennis Krohn @krohnden <dennis.krohn@th-luebeck.de>
+ */
+if ( !defined( 'MEDIAWIKI' ) ) {
+    die( "This file cannot be run standalone.\n" );
+}
+
+use MediaWiki\MediaWikiServices;
+
 class LoopPdf {
 	
-	public static function structure2pdf(LoopStructure $structure) {
+	/*
+	* Turns given LoopStructure into PDF.
+	* @params LoopStructure $structure
+	* @params Array $modifiers
+	* 			-> "pagetest" = true: return will be modified for single page test support.
+	*/
+	public static function structure2pdf(LoopStructure $structure, $modifiers = null) {
 		global $IP, $wgXmlfo2PdfServiceUrl, $wgXmlfo2PdfServiceToken;
 	
 		#require_once ($IP."/extensions/Loop/xsl/LoopXsl.php");
 	
-		$unique = uniqid();
+		#$unique = uniqid();
 	
 		$wiki_xml = LoopXml::structure2xml($structure);
+		$errors = '';
 		#var_dump($wiki_xml);exit;
 		try {
 			$xml = new DOMDocument();
 			$xml->loadXML($wiki_xml);
 		} catch (Exception $e) {
-			var_dump($e);
+			$errors .= $e . "\n";
 		}
 	
 		try {
 			$xsl = new DOMDocument;
 			$xsl->load($IP.'/extensions/Loop/xsl/pdf.xsl');
 		} catch (Exception $e) {
-			var_dump($e);
+			$errors .= $e . "\n";
 		}
 	
 		try {
@@ -29,12 +48,33 @@ class LoopPdf {
 			$proc->registerPHPFunctions();
 			$proc->importStyleSheet($xsl);
 			$xmlfo = $proc->transformToXML($xml);
+
+			if ( is_array( $modifiers ) && !empty( $xmlfo ) && $modifiers["pagetest"] == true ) { 
+				#modify content so pdf still works in single-page test mode
+				$dom = new DomDocument();
+				$dom->loadXML( $xmlfo );
+				$linkTags = $dom->getElementsByTagNameNS ("http://www.w3.org/1999/XSL/Format", "basic-link"); 
+				$refTags = $dom->getElementsByTagNameNS ("http://www.w3.org/1999/XSL/Format", "page-number-citation"); 
+				$lastRefTags = $dom->getElementsByTagNameNS ("http://www.w3.org/1999/XSL/Format", "page-number-citation-last");
+				foreach ( $linkTags as $tag ) {
+					$tag->setAttribute( "internal-destination", "article".$structure->mainPage );
+				}
+				foreach ( $refTags as $tag ) {
+						$tag->setAttribute( "ref-id", "article".$structure->mainPage );
+				}
+				foreach ( $lastRefTags as $tag ) {
+						$tag->setAttribute( "ref-id", "article".$structure->mainPage );
+				}
+				$xmlfo = $dom->saveXML();
+				
+			}
+
 		} catch (Exception $e) {
-			var_dump($e);
+			$errors .= $e . "<br>";
 		}
-	
-		#dd($xmlfo); // display xmlfo and exit
 		
+
+		#dd($xmlfo);
 		$url = $wgXmlfo2PdfServiceUrl. '?token='.$wgXmlfo2PdfServiceToken;
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_POST, 1);
@@ -43,9 +83,112 @@ class LoopPdf {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		$pdf = curl_exec($ch);
 		curl_close($ch);
-	
-		return $pdf;
+
+
+		#dd($pdf);
+
+		
+		if ( is_array( $modifiers ) && $modifiers["pagetest"] == true ) { 
+			return array( "pdf" => $pdf, "errors" => $errors, "xmlfo" => $xmlfo );
+		} else {
+			if ( !empty($errors) ) {
+				var_dump($errors);
+			}
+			
+			if ( strpos( $pdf, "%PDF") !== 0 ) {
+				var_dump( "Error!", $pdf, $xmlfo, $wiki_xml );exit;
+			}
+			#var_dump( "Debug! PDF funktioniert eigentlich. ", $xmlfo, $wiki_xml );exit;
+			return $pdf;
+		}
 	
 	}	
 	
+}
+
+
+class SpecialLoopExportPdfTest extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'LoopExportPdfTest' );
+	}
+	
+	public function execute( $sub ) {
+	
+		#global $IP, $wgXmlfo2PdfServiceUrl, $wgXmlfo2PdfServiceToken;
+
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+		$linkRenderer->setForceArticlePath(true);
+
+		$out = $this->getOutput();
+		$request = $this->getRequest();
+		$user = $this->getUser();
+		Loop::handleLoopRequest( $out, $request, $user ); #handle editmode
+
+		$out->setPageTitle( $this->msg( 'loopexportpdftest' ) );
+
+		$out->addHtml ('<h1>');
+		$out->addWikiMsg( 'loopexportpdftest' );
+		$out->addHtml ('</h1>');
+		$loopStructure = new LoopStructure();
+		$loopStructure->loadStructureItems();
+		
+		if ( $user->isAllowed('loop-edit-literature') ) {
+
+			$html = "";
+			foreach ( $loopStructure->structureItems as $item ) {
+				#reset item
+				$item->previousArticle = 0;
+				$item->structure = 1000;
+				$item->nextArticle = 0;
+				$item->parentArticle = 0;
+				$item->sequence = 0;
+				$item->tocLevel = 0;
+				# create fake structure to make pdf with (id 1 is not used")
+				$fakeTmpStructure = new LoopStructure(1000);
+				$fakeTmpStructure->structureItems = array( $item );
+				$fakeTmpStructure->mainPage = $item->article;
+				
+
+				#dd($loopStructure, $item);
+				$tmpXml = LoopXml::structure2xml( $fakeTmpStructure );
+				$tmpPdf = LoopPdf::structure2pdf( $fakeTmpStructure, array( "pagetest" => true ) );
+
+
+				if ( $item->article == 28 ) {
+					#dd( $tmpXml, $tmpPdf );
+				}
+
+				if ( strpos( $tmpPdf["pdf"], "%PDF") === 0 ) {
+					#dd("this is a pdf!", $tmpXml);
+				#$data = 
+					$html .= $item->tocNumber . " " . $item->tocText . " OK!<br>";
+				} else {
+					$html .= $linkRenderer->makelink(
+						Title::newFromID( $item->article ), 
+						new HtmlArmor( "<b>".$item->tocNumber . " " . $item->tocText . " NOT OK!</b> (ID $item->article)" ),
+						array('target' => '_blank' )
+						);
+
+					$html .= "<br><br>";
+					$html .= "<nowiki>". $tmpPdf["pdf"] . "</nowiki><br>";
+					$html .= $tmpPdf["errors"] . "<br>";
+					
+					#dd("this is not a pdf, it's " . $item->article . "'s fault!", $tmpXml, $tmpPdf);
+					break;
+				}
+				#dd($loopStructure, $item, $item->getDirectChildItems());
+				#dd($item, $loopStructure, $fakeTmpStructure->getStructureItems(), $tmpXml, $tmpPdf);
+				#$
+			}
+		} else {
+			$html = '<div class="alert alert-warning" role="alert">' . $this->msg( 'specialpage-no-permission' ) . '</div>';
+		}
+		
+		$out->addHtml($html);
+
+	}
+	protected function getGroupName() {
+		return 'loop';
+	}
 }

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -19,8 +19,8 @@ class LoopStructure {
 	public $mainPage; // article id of the main page
 	public $structureItems = array(); // array of structure items
 
-	function __construct() {
-		$this->id = 0;
+	function __construct( $id = 0 ) {
+		$this->id = $id;
 	}
 
 	public function getId() {

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -2034,13 +2034,6 @@ class wiki2xml
 				$xml = str_replace ( " <" , "<space/><" , $xml ) ;
 			}
 			$xml = str_replace ( '<tablerow></tablerow>' , '' , $xml ) ;
-			#$xml = str_replace ( '<xhtml:cite' , '<xhtml:cite xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); #remove error log warning "Namespace prefix xhtml on cite is not defined on cite"
-			#$xml = str_replace ( '<xhtml:br' , '<xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
-			#$xml = str_replace ( '<xhtml:code' , '<xhtml:code xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
-			#$xml = str_replace ( '<xhtml:tt' , '<xhtml:tt xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
-			#$xml = str_replace ( '<xhtml:pre' , '<xhtml:pre xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
-			#$xml = str_replace ( '<xhtml:p' , '<xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
-		#	$xml = str_replace ( '<xhtml:br' , '<xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
 
 			return $xml ;
 	}

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -40,7 +40,7 @@ class LoopXml {
 		$toc = self::structureItemToc($loopStructureItems[0]);
 		$xml .= "<toc>".$toc."</toc>\n";
 		
-		$articles = "<articles>";
+		$articles = '<articles xmlns:xhtml="http://www.w3.org/1999/xhtml">';
 		foreach ( $loopStructureItems as $loopStructureItem ) {
 		    $articles .= self::structureItem2xml ( $loopStructureItem, $modifiers );
 		}
@@ -146,9 +146,11 @@ class LoopXml {
 		$idCache = array();
 		$objectTags = array(  );
 		$dom = new DOMDocument( "1.0", "utf-8" );
+		#$dom->createAttributeNS( "http://www.w3.org/1999/xhtml", "xmlns:xhtml");
 		$objectTags = array( 'loop_figure', 'loop_formula', 'loop_listing', 'loop_media', 'loop_table', 'loop_task', 'cite', 'loop_index' ); # all tags with ids
 		$xml = $contentText;
 		$dom->loadXml($xml);
+		#dd($xml);
 		$selector = new DOMXPath( $dom );
 		$nodes = $selector->query( '//extension' );
 
@@ -315,8 +317,14 @@ class LoopXml {
 	
 		$return_xml = '';
 	
-		if ($link_parts['type']=='external') {
-			$return_xml =  '<php_link_external href="'.$link_parts['href'].'">'.$link_parts['text'].'</php_link_external>' ;
+		if ($link_parts['type']=='external' ) {
+			if ( array_key_exists( "href", $link_parts ) ) {
+				$return_xml = '<php_link_external href="'.$link_parts['href'].'">';
+				$return_xml .= ( array_key_exists( "text", $link_parts ) ) ? $link_parts['text'] : " ";
+				$return_xml .= '</php_link_external>' ;
+			} else {
+				$return_xml = "";
+			}
 		} else {
 			if (isset($link_parts['target'])) {
 				$target_title = Title::newFromText($link_parts['target']);
@@ -2026,6 +2034,13 @@ class wiki2xml
 				$xml = str_replace ( " <" , "<space/><" , $xml ) ;
 			}
 			$xml = str_replace ( '<tablerow></tablerow>' , '' , $xml ) ;
+			#$xml = str_replace ( '<xhtml:cite' , '<xhtml:cite xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); #remove error log warning "Namespace prefix xhtml on cite is not defined on cite"
+			#$xml = str_replace ( '<xhtml:br' , '<xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
+			#$xml = str_replace ( '<xhtml:code' , '<xhtml:code xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
+			#$xml = str_replace ( '<xhtml:tt' , '<xhtml:tt xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
+			#$xml = str_replace ( '<xhtml:pre' , '<xhtml:pre xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
+			#$xml = str_replace ( '<xhtml:p' , '<xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
+		#	$xml = str_replace ( '<xhtml:br' , '<xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" ', $xml ); 
 
 			return $xml ;
 	}

--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -78,10 +78,13 @@ class LoopXsl {
 		try {
 		    $math = new MathMathML($mathcontent);
 		    $math->render();
-		    $return = $math->getHtmlOutput();
+			$return = $math->getHtmlOutput();
+			
+			#dd($return);
 		} catch (Exception $e) {
 		    $return = '<math></math>';
 		}
+		$return1 = $return;
 		
 		$dom = new DOMDocument;
 		$dom->loadXML( $return );
@@ -99,6 +102,9 @@ class LoopXsl {
 		
 		}
 		restore_error_handler();
+		if ( strpos( $mathcontent, "\\eta" ) !== false ) {
+			#dd("!!!", $mathcontent, $return1, $return, $doc->saveXML(),$math, $mathnode->C14N() );
+		}
 		#dd($input,$doc->saveXML(),$math);
 		return $return;	
 		
@@ -310,22 +316,23 @@ class LoopXsl {
 	
 	public static function xsl_get_bibliography( $input ) {
 	    global $wgLoopLiteratureCiteType;
-	    #dd($input[0]);
-	    $input_object = $input[0];
 		$dom = new DOMDocument( "1.0", "utf-8" );
-	    
-	    if ( empty ( $input_object ) ) {
-	        $xml = '<bibliography>'.SpecialLoopLiterature::renderBibliography('xml')."</bibliography>";
-	        $dom->loadXML($xml);
-	    } else {
-	        $dom->appendChild($dom->importNode($input_object, true));
-	        $tags = $dom->getElementsByTagName ("extension"); 
-	        $input = $tags[0]->nodeValue;
-	        $xml = '<bibliography>'.LoopLiterature::renderLoopLiterature($input)."</bibliography>";
-	        $dom = new DOMDocument( "1.0", "utf-8" );
-	        $dom->loadXML($xml);
-	    }
-	    return $dom;
+		if ( !empty( $input ) ) {
+			$input_object = $input[0];
+			
+			if ( empty ( $input_object ) ) {
+				$xml = '<bibliography>'.SpecialLoopLiterature::renderBibliography('xml')."</bibliography>";
+				$dom->loadXML($xml);
+			} else {
+				$dom->appendChild($dom->importNode($input_object, true));
+				$tags = $dom->getElementsByTagName ("extension"); 
+				$input = $tags[0]->nodeValue;
+				$xml = '<bibliography>'.LoopLiterature::renderLoopLiterature($input)."</bibliography>";
+				$dom = new DOMDocument( "1.0", "utf-8" );
+				$dom->loadXML($xml);
+			}
+		}
+		return $dom;
 	}
 
 	public static function get_page_link( $input ) {

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2537,13 +2537,13 @@
 			<xsl:choose>
 				<xsl:when test="@pages">
 					<xsl:text>, </xsl:text>	
-					<xsl:value-of select="$word_cite_pages"></xsl:value-of>
+					<xsl:value-of select="$word_literature_pages"></xsl:value-of>
 					<xsl:value-of select="@pages"></xsl:value-of>
 					<xsl:text> </xsl:text>	
 				</xsl:when>
 				<xsl:when test="@page">
 					<xsl:text>, </xsl:text>	
-					<xsl:value-of select="$word_cite_page"></xsl:value-of>
+					<xsl:value-of select="$word_literature_page"></xsl:value-of>
 					<xsl:value-of select="@page"></xsl:value-of>
 					<xsl:text> </xsl:text>	
 				</xsl:when>
@@ -2927,7 +2927,7 @@
 			</fo:list-item-body>
 		</fo:list-item>
 	</xsl:template>	
-
+	
 	<xsl:template match="table">
 		<fo:table table-layout="auto" border-style="solid" border-width="0.5pt" border-color="black" border-collapse="collapse" padding="0.6pt" space-after="12.5pt">
 				<fo:table-body>
@@ -2952,7 +2952,7 @@
         	<xsl:attribute name="border-color">black</xsl:attribute>
         	<xsl:attribute name="border-collapse">collapse</xsl:attribute>
 			
-			<xsl:call-template name="css-style-attributes"></xsl:call-template>
+			<!-- <xsl:call-template name="css-style-attributes"></xsl:call-template> -->
 			
 			
         	<xsl:if test="@colspan">
@@ -2978,7 +2978,7 @@
         	<xsl:attribute name="border-color">black</xsl:attribute>
         	<xsl:attribute name="border-collapse">collapse</xsl:attribute>
 			
-			<xsl:call-template name="css-style-attributes"></xsl:call-template>
+			<!-- <xsl:call-template name="css-style-attributes"></xsl:call-template> -->
 			
         	<xsl:if test="@colspan">
 				<xsl:attribute name="number-columns-spanned"><xsl:value-of select="@colspan"></xsl:value-of></xsl:attribute>
@@ -2987,17 +2987,78 @@
 				<xsl:attribute name="number-rows-spanned"><xsl:value-of select="@rowspan"></xsl:value-of></xsl:attribute>
         	</xsl:if>        	           	        	
         	
-        	<!-- 
-			<fo:block font-weight="bold" break-before="column">
-        			<xsl:apply-templates></xsl:apply-templates>
-			</fo:block>
- 			-->
 			<fo:block font-weight="bold" >
         			<xsl:apply-templates></xsl:apply-templates>
 			</fo:block>		
 		
         </fo:table-cell>
-    </xsl:template>	
+    </xsl:template>
+
+	<xsl:template name="css-style-attributes">
+		<xsl:variable name="cssentries">
+			<xsl:call-template name="str:tokenize">
+				<xsl:with-param name="string" select="translate(@style,' ','')" />
+				<xsl:with-param name="delimiters" select="';'" />
+			</xsl:call-template>
+		</xsl:variable>		
+		<xsl:for-each select="exsl:node-set($cssentries)/node()">
+			<xsl:call-template name="css-style-attribute">
+				<xsl:with-param name="cssentry" select="." />
+			</xsl:call-template>
+		</xsl:for-each>
+	</xsl:template>
+	
+	
+	<xsl:template name="css-style-attribute">
+		<xsl:param name="cssentry"></xsl:param>
+		
+		<xsl:variable name="cssparts">
+			<xsl:call-template name="str:tokenize">
+				<xsl:with-param name="string" select="$cssentry" />
+				<xsl:with-param name="delimiters" select="':'" />
+			</xsl:call-template>
+		</xsl:variable>			
+		
+		<xsl:variable name="csskey">
+			<xsl:value-of select="exsl:node-set($cssparts)/node()[1]"/>
+		</xsl:variable>
+		<xsl:variable name="cssvalue">
+			<xsl:value-of select="exsl:node-set($cssparts)/node()[2]"/>
+		</xsl:variable>
+		
+		<xsl:choose>
+			<xsl:when test="$csskey='background-color'">
+				<xsl:attribute name="background-color">
+					<xsl:value-of select="$cssvalue"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$csskey='background'">
+				<xsl:attribute name="background-color">
+					<xsl:value-of select="$cssvalue"/>
+				</xsl:attribute>
+			</xsl:when>			
+			<xsl:when test="$csskey='color'">
+				<xsl:attribute name="color">
+					<xsl:value-of select="$cssvalue"/>
+				</xsl:attribute>
+			</xsl:when>
+			<xsl:when test="$csskey='text-align'">
+				<xsl:attribute name="text-align">
+					<xsl:choose>
+						<xsl:when test="$cssvalue='right'">
+							<xsl:text>end</xsl:text>
+						</xsl:when>
+						<xsl:when test="$cssvalue='center'">
+							<xsl:text>center</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>start</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+			</xsl:when>			
+		</xsl:choose>
+	</xsl:template>
 	
 	<xsl:template match="extension[@extension_name='loop_screenshot']">
 		


### PR DESCRIPTION
fix #98 

- Spezial:PDF_seitenweise_testen mit neuem Recht für alle, die auch editieren dürfen.
- Spezial:PDF_seitenweise_testen?articleId=194 zum seitenweisen Testen von spezifischen Seiten
- Man kann jetzt Strukturen mit anderen IDs als 0 anlegen
- Tabellen funktionieren in PDF
- unterschiedlichste fixes für PDF
