### PR TITLE
Fixes Part 2

### DIFF
--- a/includes/LoopParagraph.php
+++ b/includes/LoopParagraph.php
@@ -20,7 +20,7 @@ class LoopParagraph {
         $html .= '<div class="loopparagraph_left">';
         $html .= '<span class="ic ic-citation"></span>';
         $html .= '</div>';
-        $html .= '<div class="loopparagraph_right">';
+        $html .= '<div class="loopparagraph_right"><blockquote>';
         $html .= $parser->recursiveTagParseFully( $input );
         $html .= '</div>';
         
@@ -28,7 +28,7 @@ class LoopParagraph {
             $html .= '<span class="loopparagraph_copyright">' . $args['copyright'] . '</span>';
         }
 
-        $html .= '</div>';
+        $html .= '</blockquote></div>';
 
         return $html;
     }

--- a/includes/LoopSidenote.php
+++ b/includes/LoopSidenote.php
@@ -24,9 +24,9 @@ class LoopSidenote {
             }
         }
 
-        $html = '<span class="loopsidenote loopsidenote_' . $type . '">';
+        $html = '<div class="loopsidenote loopsidenote_' . $type . '">';
         $html .= $parser->recursiveTagParseFully( $input );
-        $html .= '</span>';
+        $html .= '</div>';
 
         return $html;
     }


### PR DESCRIPTION
- chrome=1 aus meta entfernt aufgrund w3-Validator: https://www.mediaevent.de/meta/
- Entfernung alt-Tag Login-Button (da kein Bild)
- `<section>` -> `<header>` aufgrund Semantik
- LoopParagraph erhält `<blockquote>`
- Breadcrumb ist nun `<nav>`
- Seitenmenü kann nun ebenfalls wie User-Menü geschlossen werden indem irgendeine freie Fläche geklickt wird
- Seitenmenü nun per Tab-Selektion durchwählbar. 
- Tabindex der Navigation gefixt. Durchwechseln per Tab nun ohne doppeltes Klicken möglich
- Sidenote-Container nun `<div>`
- **Work in Progress**: Per Tab Key durchwechselbare Button-Dropdowns für Barrierearmheit. Einzelne Spezialfälle müssen noch abgefangen werden.