### PR TITLE
Fix breadcrumb + Legacy Page Numbering

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -813,6 +813,10 @@
 			"value": true,
 			"description" : "Default value for activating object numberings"
 		},
+		"LoopPageNumbering": {
+			"value": "true",
+			"description" : "Default value for activating page numberings"
+		},
 		"LoopNumberingType": {
 			"value": "ongoing",
 			"description" : "Setting default type for numbering of objects [ongoing|chapter]"
@@ -837,7 +841,6 @@
 			"value": "",
 			"description" : "URL for rendering screenshots service"
 		}
-
 	},
 	"LogTypes": [ "loopexport" ],
     "LogNames": {

--- a/extension.json
+++ b/extension.json
@@ -813,7 +813,7 @@
 			"value": true,
 			"description" : "Default value for activating object numberings"
 		},
-		"LoopPageNumbering": {
+		"LegacyPageNumbering": {
 			"value": "true",
 			"description" : "Default value for activating page numberings"
 		},

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -51,7 +51,7 @@ class LoopStructure {
 				$title = Title::newFromID( $structureItem->article );
 				$link = $structureItem->tocNumber . ' '. $structureItem->tocText;
 
-				if( $wgLegacyPageNumbering ) {
+				if ( $wgLegacyPageNumbering ) {
 					$pageNumber = '<span class="loopstructure-number">' . $structureItem->tocNumber . '</span> ';
 				} else {
 					$pageNumber = '';
@@ -693,7 +693,7 @@ class LoopStructureItem {
 	    $linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 	    $linkRenderer->setForceArticlePath(true);
 		
-		if( $wgLegacyPageNumbering ) {
+		if ( $wgLegacyPageNumbering ) {
 			$pageNumber = $this->tocNumber . ' ';
 		} else {
 			$pageNumber = '';
@@ -736,7 +736,7 @@ class LoopStructureItem {
 			
 			$title = Title::newFromID( $item->article );
 
-			if( $wgLegacyPageNumbering ) {
+			if ( $wgLegacyPageNumbering ) {
 				$pageNumber = $item->tocNumber . ' ';
 			} else {
 				$pageNumber = '';

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -682,8 +682,10 @@ class LoopStructureItem {
 
 	    $linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 	    $linkRenderer->setForceArticlePath(true);
+		
+		//preventing home page occouring on breadcrumb nav
+		$breadcrumb = (empty($this->tocNumber)) ? '' : '<li class="active">' . $this->tocNumber . ' ' . $this->tocText .'</li>';
 
-		$breadcrumb = '<li class="active">' . $this->tocNumber . ' ' . $this->tocText .'</li>';
 		$len = strlen( $this->tocNumber ) + strlen( $this->tocText ) + 1;
 		$level = $this->tocLevel;
 
@@ -706,15 +708,19 @@ class LoopStructureItem {
 		$max_item_text_len = floor( $max_text_len / $level );
 
 		foreach( $items as $item ) {
+			
+			// if home page -> skip
+			if(empty($item->tocNumber)) continue;
 
-			if( strlen( $item->tocText ) > $max_item_text_len ) {
+			if( strlen( $item->tocText ) > $max_item_text_len) {
 				$link_text = mb_substr( $item->tocText, 0, ( $max_item_text_len - 2 ) ) . '..';
 			} else {
 				$link_text = $item->tocText;
 			}
-
+			
 			$title = Title::newFromID( $item->article );
 			$link = $linkRenderer->makeLink( $title, new HtmlArmor( $item->tocNumber .' '. $link_text ) );
+			
 			$breadcrumb = '<li>' . $link .'</li>' . $breadcrumb;
 
 		}

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -29,6 +29,8 @@ class LoopStructure {
 
 	public function render() {
 
+		global $wgLoopPageNumbering;
+
 		$text = '';
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 		$linkRenderer->setForceArticlePath(true);
@@ -48,15 +50,21 @@ class LoopStructure {
 				}
 				$title = Title::newFromID( $structureItem->article );
 				$link = $structureItem->tocNumber . ' '. $structureItem->tocText;
+
+				if( $wgLoopPageNumbering ) {
+					$pageNumber = '<span class="loopstructure-number">' . $structureItem->tocNumber . '</span> ';
+				} else {
+					$pageNumber = '';
+				}
+
 				if ( $title ) {
 					$link = $linkRenderer->makeLink(
 						Title::newFromID( $structureItem->article ),
-						new HtmlArmor( '<span class="loopstructure-number">'.$structureItem->tocNumber .'</span> '. $structureItem->tocText )
+						new HtmlArmor( $pageNumber . $structureItem->tocText )
 					);
 					
 				} 
-				$text .= '<div class="loopstructure-listitem loopstructure-level-'.$structureItem->tocLevel.'">' . str_repeat('	',  $tabLevel ) . $link . '</div>';
-				
+				$text .= '<div class="loopstructure-listitem loopstructure-level-'.$structureItem->tocLevel.'">' . str_repeat(' ',  $tabLevel ) . $link . '</div>';
 				
 			}
 
@@ -680,11 +688,19 @@ class LoopStructureItem {
 
 	public function getBreadcrumb ( $max_len = 100 ) {
 
+		global $wgLoopPageNumbering;
+
 	    $linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 	    $linkRenderer->setForceArticlePath(true);
 		
+		if( $wgLoopPageNumbering ) {
+			$pageNumber = $this->tocNumber . ' ';
+		} else {
+			$pageNumber = '';
+		}
+
 		//preventing home page occouring on breadcrumb nav
-		$breadcrumb = (empty($this->tocNumber)) ? '' : '<li class="active">' . $this->tocNumber . ' ' . $this->tocText .'</li>';
+		$breadcrumb = (empty($this->tocNumber)) ? '' : '<li class="active">' . $pageNumber . ' ' . $this->tocText .'</li>';
 
 		$len = strlen( $this->tocNumber ) + strlen( $this->tocText ) + 1;
 		$level = $this->tocLevel;
@@ -719,7 +735,14 @@ class LoopStructureItem {
 			}
 			
 			$title = Title::newFromID( $item->article );
-			$link = $linkRenderer->makeLink( $title, new HtmlArmor( $item->tocNumber .' '. $link_text ) );
+
+			if( $wgLoopPageNumbering ) {
+				$pageNumber = $item->tocNumber . ' ';
+			} else {
+				$pageNumber = '';
+			}
+
+			$link = $linkRenderer->makeLink( $title, new HtmlArmor( $pageNumber . $link_text ) );
 			
 			$breadcrumb = '<li>' . $link .'</li>' . $breadcrumb;
 

--- a/includes/LoopStructure.php
+++ b/includes/LoopStructure.php
@@ -29,7 +29,7 @@ class LoopStructure {
 
 	public function render() {
 
-		global $wgLoopPageNumbering;
+		global $wgLegacyPageNumbering;
 
 		$text = '';
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
@@ -51,7 +51,7 @@ class LoopStructure {
 				$title = Title::newFromID( $structureItem->article );
 				$link = $structureItem->tocNumber . ' '. $structureItem->tocText;
 
-				if( $wgLoopPageNumbering ) {
+				if( $wgLegacyPageNumbering ) {
 					$pageNumber = '<span class="loopstructure-number">' . $structureItem->tocNumber . '</span> ';
 				} else {
 					$pageNumber = '';
@@ -688,12 +688,12 @@ class LoopStructureItem {
 
 	public function getBreadcrumb ( $max_len = 100 ) {
 
-		global $wgLoopPageNumbering;
+		global $wgLegacyPageNumbering;
 
 	    $linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 	    $linkRenderer->setForceArticlePath(true);
 		
-		if( $wgLoopPageNumbering ) {
+		if( $wgLegacyPageNumbering ) {
 			$pageNumber = $this->tocNumber . ' ';
 		} else {
 			$pageNumber = '';
@@ -736,7 +736,7 @@ class LoopStructureItem {
 			
 			$title = Title::newFromID( $item->article );
 
-			if( $wgLoopPageNumbering ) {
+			if( $wgLegacyPageNumbering ) {
 				$pageNumber = $item->tocNumber . ' ';
 			} else {
 				$pageNumber = '';

--- a/includes/LoopToc.php
+++ b/includes/LoopToc.php
@@ -42,7 +42,7 @@ class LoopToc extends LoopStructure {
 			$next = $lsi->getNextItem();
 			$tocNumber =  $lsi->getTocNumber();
 			
-			if( $wgLegacyPageNumbering ) {
+			if ( $wgLegacyPageNumbering ) {
 				$pageNumber = $tocNumber . ' ';
 			} else {
 				$pageNumber = '';

--- a/includes/LoopToc.php
+++ b/includes/LoopToc.php
@@ -67,17 +67,17 @@ class LoopToc extends LoopStructure {
 							$tmp_pageNumber = '';
 						}
 
-						if( isset( $tmp_lsi->tocLevel ) && $tmp_lsi->tocLevel > 0 ) {
+						//if( isset( $tmp_lsi->tocLevel ) && $tmp_lsi->tocLevel > 0 ) {
 							$tabLevel = $tmp_lsi->tocLevel;
-						} else {
-							$tabLevel = 1;
-						}
+					//	} else {
+						//	$tabLevel = 1;
+						//}
 
 						$link = $linkRenderer->makeLink(
 							Title::newFromID( $tmp_lsi->article ),
 							new HtmlArmor( '<span class="loopstructure-number">' . $tmp_pageNumber .'</span>' . $tmp_lsi->tocText )
 						);
-						$html .= '<div class="loopstructure-listitem loopstructure-level-' . $tmp_lsi->tocLevel . '">' . str_repeat(' ',  $tabLevel ) . $link . '</div>';
+						$html .= '<div class="loopstructure-listitem loopstructure-level-' . $tmp_lsi->tocLevel . '">' . ' ' . $link . '</div>';
                         $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$tmp_lsi->article.'"><bold>'. $tmp_pageNumber .'</bold> '. $tmp_lsi->tocText . '</php_link_internal></loop_toc_list>';
 
 					} else {

--- a/includes/LoopToc.php
+++ b/includes/LoopToc.php
@@ -28,7 +28,7 @@ class LoopToc extends LoopStructure {
     
     public static function outputLoopToc( $rootArticleId, $output = "html" ) {
 
-		global $wgLoopPageNumbering;
+		global $wgLegacyPageNumbering;
 
 		$html = '';
 		$xml = '';
@@ -42,7 +42,7 @@ class LoopToc extends LoopStructure {
 			$next = $lsi->getNextItem();
 			$tocNumber =  $lsi->getTocNumber();
 			
-			if( $wgLoopPageNumbering ) {
+			if( $wgLegacyPageNumbering ) {
 				$pageNumber = $tocNumber . ' ';
 			} else {
 				$pageNumber = '';
@@ -53,7 +53,7 @@ class LoopToc extends LoopStructure {
 				new HtmlArmor( '<span class="loopstructure-number">' . $pageNumber .'</span>' . $tocText )
 			);
             $html .= '<div class="loopstructure-listitem loopstructure-level-' . $level . '">' . $headLink . '</div>';
-            $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$rootArticleId.'"><bold>'. $tocNumber .'</bold>  '. $tocText . '</php_link_internal></loop_toc_list>';
+            $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$rootArticleId.'"><bold>'. $pageNumber .'</bold>  ' . $tocText . '</php_link_internal></loop_toc_list>';
 			
 			while ( !empty ( $next ) ) {
 				$tmp_lsi = $next;
@@ -61,7 +61,7 @@ class LoopToc extends LoopStructure {
 					if ( empty( $tocNumber ) || strpos ( $tmp_lsi->tocNumber, $tocNumber ) === 0 ) { # the root page's toc number must be inside the displayed toc number
 						$next = $tmp_lsi->getNextItem();
 						
-						if( $wgLoopPageNumbering ) {
+						if( $wgLegacyPageNumbering ) {
 							$tmp_pageNumber = $tmp_lsi->tocNumber . ' ';
 						} else {
 							$tmp_pageNumber = '';
@@ -78,7 +78,7 @@ class LoopToc extends LoopStructure {
 							new HtmlArmor( '<span class="loopstructure-number">' . $tmp_pageNumber .'</span>' . $tmp_lsi->tocText )
 						);
 						$html .= '<div class="loopstructure-listitem loopstructure-level-' . $tmp_lsi->tocLevel . '">' . ' ' . $link . '</div>';
-                        $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$tmp_lsi->article.'"><bold>'. $tmp_pageNumber .'</bold> '. $tmp_lsi->tocText . '</php_link_internal></loop_toc_list>';
+                        $xml .= '<loop_toc_list> <php_link_internal text-decoration="no-underline" href="article'.$tmp_lsi->article.'"><bold>'. $tmp_pageNumber .'</bold> '. $tmp_lsi->tocText . '</php_link_internal></loop_toc_list>';
 
 					} else {
 						break;

--- a/includes/LoopToc.php
+++ b/includes/LoopToc.php
@@ -28,6 +28,8 @@ class LoopToc extends LoopStructure {
     
     public static function outputLoopToc( $rootArticleId, $output = "html" ) {
 
+		global $wgLoopPageNumbering;
+
 		$html = '';
 		$xml = '';
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
@@ -40,9 +42,15 @@ class LoopToc extends LoopStructure {
 			$next = $lsi->getNextItem();
 			$tocNumber =  $lsi->getTocNumber();
 			
+			if( $wgLoopPageNumbering ) {
+				$pageNumber = $tocNumber . ' ';
+			} else {
+				$pageNumber = '';
+			}
+
 			$headLink = $linkRenderer->makeLink(
 				Title::newFromID( $lsi->article ),
-				new HtmlArmor( '<span class="loopstructure-number">' . $tocNumber .'</span> ' . $tocText )
+				new HtmlArmor( '<span class="loopstructure-number">' . $pageNumber .'</span>' . $tocText )
 			);
             $html .= '<div class="loopstructure-listitem loopstructure-level-' . $level . '">' . $headLink . '</div>';
             $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$rootArticleId.'"><bold>'. $tocNumber .'</bold>  '. $tocText . '</php_link_internal></loop_toc_list>';
@@ -53,12 +61,24 @@ class LoopToc extends LoopStructure {
 					if ( empty( $tocNumber ) || strpos ( $tmp_lsi->tocNumber, $tocNumber ) === 0 ) { # the root page's toc number must be inside the displayed toc number
 						$next = $tmp_lsi->getNextItem();
 						
+						if( $wgLoopPageNumbering ) {
+							$tmp_pageNumber = $tmp_lsi->tocNumber . ' ';
+						} else {
+							$tmp_pageNumber = '';
+						}
+
+						if( isset( $tmp_lsi->tocLevel ) && $tmp_lsi->tocLevel > 0 ) {
+							$tabLevel = $tmp_lsi->tocLevel;
+						} else {
+							$tabLevel = 1;
+						}
+
 						$link = $linkRenderer->makeLink(
 							Title::newFromID( $tmp_lsi->article ),
-							new HtmlArmor( '<span class="loopstructure-number">' . $tmp_lsi->tocNumber .'</span> ' . $tmp_lsi->tocText )
+							new HtmlArmor( '<span class="loopstructure-number">' . $tmp_pageNumber .'</span>' . $tmp_lsi->tocText )
 						);
-						$html .= '<div class="loopstructure-listitem loopstructure-level-' . $tmp_lsi->tocLevel . '">' . $link . '</div>';
-                        $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$tmp_lsi->article.'"><bold>'. $tmp_lsi->tocNumber .'</bold>  '. $tmp_lsi->tocText . '</php_link_internal></loop_toc_list>';
+						$html .= '<div class="loopstructure-listitem loopstructure-level-' . $tmp_lsi->tocLevel . '">' . str_repeat(' ',  $tabLevel ) . $link . '</div>';
+                        $xml .= '<loop_toc_list><php_link_internal text-decoration="no-underline" href="article'.$tmp_lsi->article.'"><bold>'. $tmp_pageNumber .'</bold> '. $tmp_lsi->tocText . '</php_link_internal></loop_toc_list>';
 
 					} else {
 						break;

--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -477,4 +477,10 @@ class LoopXsl {
 		}
 		return "";		
 	}
+
+	public static function xsl_showPageNumbering() {
+		global $wgLegacyPageNumbering;
+
+		return $wgLegacyPageNumbering;
+	}
 }

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -298,6 +298,7 @@
 				<xsl:call-template name="appendix_number">
 					<xsl:with-param name="content" select="'terminology'"></xsl:with-param>
 				</xsl:call-template>
+				
 				<xsl:text> </xsl:text>			
 				<xsl:value-of select="$word_terminology"></xsl:value-of>
 			</fo:marker>
@@ -389,11 +390,11 @@
 		<xsl:param name="terminology_exists"><xsl:call-template name="terminology_exists"></xsl:call-template></xsl:param>	
 		<fo:block>
 			<fo:marker marker-class-name="page-title-left">
-				<xsl:value-of select="//loop/meta/title"></xsl:value-of>
+				<xsl:value-of select="//loop/meta/title"></xsl:value-of> 
 			</fo:marker>
 		</fo:block>
 		<fo:block>
-			<fo:marker marker-class-name="page-title-right">
+			<fo:marker marker-class-name="page-title-right"> 
 				<xsl:value-of select="$word_content"></xsl:value-of>
 			</fo:marker>
 		</fo:block>
@@ -402,7 +403,7 @@
 			<xsl:value-of select="$word_content"></xsl:value-of>
 		</fo:block>
 		
-		<xsl:call-template name="make-toc"></xsl:call-template>	
+		<xsl:call-template name="make-toc"></xsl:call-template>
 		
 		<xsl:if test="($cite_exists='1') or ($figure_exists='1') or ($table_exists='1') or ($media_exists='1') or ($task_exists='1') or ($index_exists='1') or ($glossary_exists='1')">
 			<fo:block margin-bottom="1em"></fo:block>
@@ -1213,7 +1214,11 @@
 				<xsl:value-of select="generate-id()"/> -->
 				<xsl:value-of select="@id"></xsl:value-of>
 				</xsl:attribute>
-				<xsl:value-of select="@tocnumber"></xsl:value-of>
+				
+				<xsl:if test="php:function('LoopXsl::xsl_showPageNumbering')">
+					<xsl:value-of select="@tocnumber"></xsl:value-of>
+				</xsl:if>
+
 				<xsl:text> </xsl:text>
 				<xsl:value-of select="@toctext"></xsl:value-of>
 			</fo:basic-link>
@@ -1303,7 +1308,9 @@
 								<xsl:value-of select="//loop/@title"></xsl:value-of>
 							</xsl:when>
 							<xsl:otherwise>
-								<xsl:value-of select="preceding-sibling::node()[@toclevel &lt; $toclevel][1]/@tocnumber"></xsl:value-of>
+								<xsl:if test="php:function('LoopXsl::xsl_showPageNumbering')">
+									<xsl:value-of select="preceding-sibling::node()[@toclevel &lt; $toclevel][1]/@tocnumber"></xsl:value-of>
+								</xsl:if>
 								<xsl:text> </xsl:text>
 								<xsl:value-of select="preceding-sibling::node()[@toclevel &lt; $toclevel][1]/@toctext"></xsl:value-of>
 							</xsl:otherwise>					
@@ -1312,7 +1319,10 @@
 					</fo:block>
 					<fo:block>
 						<fo:marker marker-class-name="page-title-right">
-							<xsl:value-of select="@tocnumber"></xsl:value-of>
+							<xsl:if test="php:function('LoopXsl::xsl_showPageNumbering')">
+								<xsl:value-of select="@tocnumber"></xsl:value-of>
+							</xsl:if>
+							
 							<xsl:text> </xsl:text>
 							<xsl:choose>
 								<xsl:when test="string-length(@toctext) &gt; 63">
@@ -1326,7 +1336,9 @@
 					</fo:block>
 					<fo:block keep-with-next.within-page="always">
 						<xsl:call-template name="font_head"></xsl:call-template>
-						<xsl:value-of select="@tocnumber"></xsl:value-of>
+						<xsl:if test="php:function('LoopXsl::xsl_showPageNumbering')">
+							<xsl:value-of select="@tocnumber"></xsl:value-of>
+						</xsl:if>
 						<xsl:text> </xsl:text>
 						<xsl:value-of select="@toctext"></xsl:value-of>
 					</fo:block>


### PR DESCRIPTION
- Home Seite ist aus Breadcrumb entfernt
- $wgLegacyPageNumbering = false; blendet "Toc-Numbers" aus.
  - PDF (Inhaltsverzeichnis, Headertitle links + rechts, LoopToc-Element)
  - Page (Inhaltsverzeichnis, Sidebar-Toc, LoopToc-Element, Breadcrumbs)
- .oo-ui-textInputWidget input Fix da 1px zu hoch