### PR TITLE
Fix images + small fixes

### DIFF
--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -120,25 +120,28 @@ class LoopHooks {
 		$user = $wgOut->getUser();
 		$loopEditMode = $user->getOption( 'LoopEditMode', false, true );
 		$parser->getOptions()->optionUsed( 'LoopEditMode' );
-		
+
 		if ( is_object( $file ) ) {
+			//dd($file);
 			$mediaType = $file->getMediaType();
 			if ( $mediaType == "BITMAP" || $mediaType == "DRAWING" ) { 
-				$params['frame']['class'] = 'responsive-image';
+				#$params['frame']['class'] = 'responsive-image';
 				if ($loopEditMode) {
-					$params['frame']['no-link'] = false;
-					$params['frame']['framed'] = true;
+					//$params['frame']['framed'] = true;
+					//$params['frame']['no-link'] = false;
 				} else {
-					$params['frame']['framed'] = true;
-					$params['frame']['no-link'] = true;
+					//$params['frame']['framed'] = true;
+					//$params['frame']['no-link'] = true;
 				}
 				if ( isset( $params['frame']['align'] ) ) {
 					$params['horizAlign'][ $params['frame']['align'] ] = true;
 				}
+				//dd($params);
+		
 			} elseif ( $mediaType == "VIDEO" ) { 
 				$params['frame']['class'] = 'responsive-video';
 				if ( !isset( $params['handler']['width'] ) ) {
-					$params['handler']['width']= "800";
+					$params['handler']['width'] = "800";
 				}
 			}  elseif ( $mediaType == "AUDIO" ) { 
 				$params['frame']['class'] = 'responsive-audio';

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -125,7 +125,7 @@ class LoopHooks {
 			//dd($file);
 			$mediaType = $file->getMediaType();
 			if ( $mediaType == "BITMAP" || $mediaType == "DRAWING" ) { 
-				#$params['frame']['class'] = 'responsive-image';
+				$params['frame']['class'] = 'responsive-image';
 				if ($loopEditMode) {
 					//$params['frame']['framed'] = true;
 					//$params['frame']['no-link'] = false;

--- a/includes/LoopFigure.php
+++ b/includes/LoopFigure.php
@@ -131,9 +131,10 @@ class LoopFigure extends LoopObject{
 			$this->setFile($filename);
 		} 
 		
-		if (preg_match ( '<div class="float-left">', $this->getContent(), $float_matches ) === 1) {
+		dd($this);
+		if (preg_match ( '<loop_figure align="left">', $this->getContent(), $float_matches ) === 1) {
 			$this->setAlignment('left');
-		} elseif (preg_match ( '<div class="float-right">', $this->getContent(), $float_matches ) === 1) {
+		} elseif (preg_match ( '<loop_figure align="right">', $this->getContent(), $float_matches ) === 1) {
 			$this->setAlignment('right');
 		}		
 		

--- a/includes/LoopFigure.php
+++ b/includes/LoopFigure.php
@@ -131,15 +131,15 @@ class LoopFigure extends LoopObject{
 			$this->setFile($filename);
 		} 
 		
-		dd($this);
+		//dd($this);
 		if (preg_match ( '<loop_figure align="left">', $this->getContent(), $float_matches ) === 1) {
-			$this->setAlignment('left');
+			//$this->setAlignment('left');
 		} elseif (preg_match ( '<loop_figure align="right">', $this->getContent(), $float_matches ) === 1) {
-			$this->setAlignment('right');
+			//$this->setAlignment('right');
+			//$this->mContent();
 		}		
 		
 	}
-	
 	
 	/**
 	 * Render loop_figure for list of figures

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -198,7 +198,19 @@ class LoopObject {
 				$showNumbering = false;
 			}
 		} 
-		$html .= 'class="loop_object '.$this->getTag().' '.$floatclass.' loop_object_render_'.$this->getRenderOption().'"';
+
+		if ( preg_match ( '<div class="thumb tright">', $this->getContent(), $float_matches ) === 1 ) {
+			$align = 'tright';
+		} else if ((preg_match ( '<div class="thumb tleft">', $this->getContent(), $float_matches ) === 1) ) {
+			$align = 'tleft';
+		} else {
+			$align = '';
+		}
+		
+		$objectContent = str_replace(['tleft', 'tright'], '', $this->getContent());
+		$objectContent = strip_tags($objectContent, '<div><img>'); //alternative finden
+
+		$html .= 'class="loop_object '.$this->getTag().' ' .$align. ' '.$floatclass.' loop_object_render_'.$this->getRenderOption().'"';
 		$html .= '>';
 		
 		if ( isset( $this->error ) ) {
@@ -207,7 +219,7 @@ class LoopObject {
 	
 		$html .= '<div class="loop_object_content">';
 
-		$html .= $this->getContent();
+		$html .= $objectContent;
 		
 		$html .= '</div>';
 			

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -8,6 +8,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( "This file cannot be run standalone.\n" );
 }
 
+use MediaWiki\MediaWikiServices;
+
 class LoopXml {
 	
 	/**
@@ -305,6 +307,7 @@ class LoopXml {
 					$child_name = 'align';
 	
 				}
+				
 			}
 			$link_parts[$child_name]=$child_value;
 		}
@@ -317,6 +320,10 @@ class LoopXml {
 	
 		$return_xml = '';
 	
+		$services = MediaWikiServices::getInstance();
+		$magicWords = $services->getContentLanguage()->getMagicWords();
+
+
 		if ($link_parts['type']=='external' ) {
 			if ( array_key_exists( "href", $link_parts ) ) {
 				$return_xml = '<php_link_external href="'.$link_parts['href'].'">';
@@ -356,12 +363,25 @@ class LoopXml {
 									}
 								}
 									
-								$return_xml =  '<php_link_image imagepath="'.$target_url.'" imagewidth="'.$imagewidth.'" ';
-								if (isset($link_parts['align'])) {
-									$return_xml .= ' align="'.$link_parts['align'].'" ';
+								$return_xml =  '<php_link_image imagepath="'.$target_url.'" imagewidth="'.$imagewidth.'"';
+
+
+								$align_arr = ['img_right', 'img_left', 'img_none', 'img_center'];
+
+								foreach ($align_arr as $arr) {
+									if($link_parts['part'] == $magicWords[$arr][1]){
+										$align = $magicWords[$arr][2];
+										break;
+									}
 								}
+								
+								if (isset($align)) {
+									$return_xml .= ' align="'.$align.'"';
+								}
+
 								$return_xml .=  '></php_link_image>';
-									
+								
+								// dd($return_xml);
 									
 							} elseif ( $file->getMediaType() == "VIDEO" ) { #render videos entered as [[File:Video.mp4]] like loop_video
 								$return_xml .= '<paragraph>';

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1315,7 +1315,7 @@
 							</xsl:choose>
 						</fo:marker>
 					</fo:block>
-					<fo:block keep-with-next.within-page="always">
+					<fo:block keep-with-next.within-page="always" intrusion-displace="line">
 						<xsl:call-template name="font_head"></xsl:call-template>
 						<xsl:if test="php:function('LoopXsl::xsl_showPageNumbering')">
 							<xsl:value-of select="@tocnumber"></xsl:value-of>
@@ -1323,7 +1323,7 @@
 						<xsl:text> </xsl:text>
 						<xsl:value-of select="@toctext"></xsl:value-of>
 					</fo:block>
-					<fo:block keep-with-previous.within-page="always">
+					<fo:block keep-with-previous.within-page="always" intrusion-displace="line">
 						<xsl:call-template name="font_normal"></xsl:call-template>
 						<xsl:apply-templates></xsl:apply-templates>
 					</fo:block>
@@ -2016,12 +2016,39 @@
 	</xsl:template>			
 
 	<xsl:template match="link">
-		<xsl:apply-templates select="php:function('LoopXml::transform_link', ., ancestor::article/@id)"></xsl:apply-templates>
-	</xsl:template> 
-	<xsl:template match="link" mode="loop_object">
-		<xsl:apply-templates select="php:function('LoopXml::transform_link', ., ancestor::article/@id)"></xsl:apply-templates>
+		<xsl:variable name="align">
+			<xsl:choose>
+				<xsl:when test="contains(.,'rechts')">end</xsl:when>
+				<xsl:when test="contains(.,'links')">start</xsl:when>
+				<xsl:otherwise>none</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<!--<fo:float>-->
+			<!--<xsl:attribute name="float" value="$align"></xsl:attribute>				
+			<xsl:choose>
+				<xsl:when test="$align='start'">
+					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
+				</xsl:when>			
+				<xsl:when test="$align='end'">
+					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
+				</xsl:when>
+				<xsl:otherwise></xsl:otherwise>
+			</xsl:choose>-->
+			<xsl:apply-templates select="php:function('LoopXml::transform_link', ., ancestor::article/@id)"></xsl:apply-templates>
+	<!--	</fo:float>-->
 	</xsl:template> 
 	
+	
+	<xsl:template match="link" mode="loop_object">
+
+			<xsl:apply-templates select="php:function('LoopXml::transform_link', ., ancestor::article/@id)"></xsl:apply-templates>
+
+	</xsl:template> 
+	
+
+
+
 	<xsl:template match="php_link">
 		<xsl:value-of select="."></xsl:value-of>
 	</xsl:template>
@@ -2048,40 +2075,40 @@
 				<xsl:when test="ancestor::extension[@extension_name='loop_figure']">inside</xsl:when>			
 				<xsl:when test="@align='left'">start</xsl:when>
 				<xsl:when test="@align='right'">end</xsl:when>
+				<xsl:when test="@align='center'">center</xsl:when>
 				<xsl:otherwise>none</xsl:otherwise>
 			</xsl:choose>
 		</xsl:variable>	
 	
 		<fo:float>
 			<xsl:attribute name="float" value="$align"></xsl:attribute>				
-				<xsl:choose>
+			<xsl:choose>
 				<xsl:when test="$align='start'">
 					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
 				</xsl:when>			
 				<xsl:when test="$align='end'">
 					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
 				</xsl:when>
-				<xsl:otherwise>
-					
-				</xsl:otherwise>
+				<xsl:otherwise></xsl:otherwise>
 			</xsl:choose>
 			
 			<xsl:if test="@imagepath">
-				<fo:block font-size="0pt" line-height="0pt" padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt" padding-left="0pt" padding-right="0pt">
-					<fo:external-graphic scaling="uniform" content-height="scale-to-fit"  dominant-baseline="reset-size">
-						<!-- <xsl:choose>
+				<fo:block font-size="0pt" line-height="0pt" padding="0pt">
+					<fo:external-graphic scaling="uniform" content-height="scale-to-fit" dominant-baseline="reset-size">
+						 <xsl:choose>
 							<xsl:when test="$align='start'">
 								<xsl:attribute name="padding-right">7mm</xsl:attribute>				
 							</xsl:when>
 							<xsl:when test="$align='end'">
-								<xsl:attribute name="padding-right">7mm</xsl:attribute>				
+								<xsl:attribute name="padding-left">7mm</xsl:attribute>				
 							</xsl:when>					
 							<xsl:otherwise>
 								<xsl:attribute name="padding-left">0mm</xsl:attribute>
 							</xsl:otherwise>
-						</xsl:choose> -->							
-						<xsl:attribute name="src" ><xsl:value-of select="@imagepath"></xsl:value-of></xsl:attribute>
-						<xsl:attribute name="max-width">145mm</xsl:attribute>
+						</xsl:choose>
+						<xsl:attribute name="src"><xsl:value-of select="@imagepath"></xsl:value-of></xsl:attribute>
+						<xsl:attribute name="content-width"><xsl:value-of select="@imagewidth"></xsl:value-of></xsl:attribute>
+						<xsl:attribute name="max-width">145mm</xsl:attribute>	
 					</fo:external-graphic>
 				</fo:block>
 			</xsl:if>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2901,7 +2901,7 @@
 		</fo:list-block>
 	</xsl:template>
 
-	<xsl:template match="listitem">
+<xsl:template match="listitem">
 		<xsl:variable name="listlevel">
 			<xsl:value-of select="count(ancestor::list)"></xsl:value-of>
 		</xsl:variable>
@@ -2909,33 +2909,31 @@
 			<fo:list-item-label end-indent="label-end()">
 				<xsl:choose>
 					<xsl:when test="../@type='numbered'">
-						
 						<xsl:choose>
-								<xsl:when test="$listlevel=1">
-									<fo:block><xsl:number level="single" count="listitem" format="1." /></fo:block>
-								</xsl:when>
-								<xsl:when test="$listlevel=2">
-									<fo:block><xsl:number level="multiple" count="listitem" format="1." /></fo:block>
-								</xsl:when>
-								<xsl:when test="$listlevel=3">
-									<fo:block><xsl:number level="multiple" count="listitem" format="1." /></fo:block>
-								</xsl:when>
-								<xsl:otherwise>
-									<fo:block><xsl:number level="multiple" count="listitem" format="1." /></fo:block>
-								</xsl:otherwise>
+							<xsl:when test="$listlevel=1">
+								<fo:block><xsl:number level="single" count="listitem" format="1."/></fo:block>
+							</xsl:when>
+							<xsl:when test="$listlevel=2">
+								<fo:block><xsl:number level="multiple" count="listitem" format="1."/></fo:block>
+							</xsl:when>
+							<xsl:when test="$listlevel=3">
+								<fo:block><xsl:number level="multiple" count="listitem" format="1."/></fo:block>
+							</xsl:when>
+							<xsl:otherwise>
+								<fo:block><xsl:number level="multiple" count="listitem" format="1."/></fo:block>
+							</xsl:otherwise>
 						</xsl:choose>
-						
 					</xsl:when>
 					<xsl:when test="../@type='ident'">
 						<fo:block padding-before="2pt"></fo:block>
-					</xsl:when>						
+					</xsl:when>
 					<xsl:otherwise>
-						<fo:block padding-before="2pt">
+						<fo:block>
 							<xsl:choose>
-								<xsl:when test="$listlevel=1">&#x2022;</xsl:when>
-								<xsl:when test="$listlevel=2">&#x20D8;</xsl:when>
-								<xsl:when test="$listlevel=3">&#x220E;</xsl:when>
-								<xsl:otherwise>&#x220E;</xsl:otherwise>
+								<xsl:when test="$listlevel=1">&#x2022;</xsl:when> <!-- unicode 'bullet' -->
+								<xsl:when test="$listlevel=2">&#x20D8;</xsl:when> <!-- unicode 'combining ring overlay' -->
+								<xsl:when test="$listlevel=3">&#x220E;</xsl:when> <!-- unicode 'end of proof' -->
+								<xsl:otherwise>&#x220E;</xsl:otherwise>			  <!-- unicode 'end of proof' -->
 							</xsl:choose>
 						</fo:block>
 					</xsl:otherwise>


### PR DESCRIPTION
- Deutsche Werte (rechts|links statt left|right) machen in Bilderausrichtung kein Problem mehr
- Bilder-Ausrichtung funktioniert auf Site (siehe Startseite von Oldenburg; PDF funktioniert noch nicht diesbezüglich. Pull Request enthält den aktuellen Stand)
- Modal hat nun rechts keinen fehlenden 1px-Rand
- Anpassungen/Fix der Listen auf Site + PDF (ToDo niedrige Prio: Listen im PDF nach einigen Verschachtelungen fixen)
- Minor Fixes
fix #169 fix #170