### PR TITLE
Upgrade fixes

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -13,19 +13,20 @@
 	"descriptionmsg": "loop-desc",
 	"licence-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": "1.33.*",
+		"MediaWiki": "1.34.*",
 		"extensions": {
-			"WikiEditor": "*",
-			"Math": "*",
-			"SyntaxHighlight": "*",
-			"EmbedVideo": ">= 2.8.0",
-			"Cite": "*",
-			"Lingo": "*",
-			"MsUpload": "*",
-			"Score": "*",
-			"Quiz": "*",
+			"Cite": ">= 1.0.0",
 			"ConfirmEdit": ">= 1.6.0",
-			"ReCaptchaNoCaptcha": "*"
+			"EmbedVideo": ">= 2.8.0",
+			"FlaggedRevs": "*",
+			"Lingo": ">= 3.0.0",
+			"Math": "3.0.0",
+			"MsUpload": ">= 13.1",
+			"Quiz": ">= 1.2.0",
+			"ReCaptchaNoCaptcha": "*",
+			"Score": ">= 0.3.0",
+			"SyntaxHighlight": ">= 2.0",
+			"WikiEditor": ">= 0.5.2"
 		}
 	},
 	"callback": "Loop::onExtensionLoad",

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -67,16 +67,12 @@ class LoopHooks {
 
 		global $wgUser, $wgOut; # $wgUser is not supposed to be used but $wgOut->getUser() does not work, as there is a session issue ("Wrong entry point")
 		$hideSpecialPages = false;
-
-		if ( !isset ( $wgUser->mRights ) ) { # no check for specific rights - anon users get blocked from viewing these special pages.
+		if ( ! in_array ( "loop-view-special-pages", $wgUser->mRights ) ) { # no check for specific rights - anon users get blocked from viewing these special pages.
 			$hideSpecialPages = true;
 		} elseif ( ! $wgOut->getUser()->isAllowed( "loop-view-special-pages" ) ) { # for logged in users, we can check the rights.
 			$hideSpecialPages = true;
-
-			#if ( ! $wgOut->getUser()->isAllowed( "loop-change-credentials" ) ) {
-			#	unset( $specialPages[ "ChangeCredentials" ] );
-			#}
 		}
+		
 		if ( $hideSpecialPages ) {
 			$hidePages = array( 'Recentchangeslinked', 'Recentchanges', 'Listredirects', 'Mostlinkedcategories', 'Export', 'Uncategorizedtemplates', 
 				'DoubleRedirects', 'DeletedContributions', 'Mostcategories', 'Block', 'Movepage', 'Mostrevisions', 'Unusedimages', 'Log', 

--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -72,7 +72,7 @@ class LoopHooks {
 		} elseif ( ! $wgOut->getUser()->isAllowed( "loop-view-special-pages" ) ) { # for logged in users, we can check the rights.
 			$hideSpecialPages = true;
 		}
-		
+
 		if ( $hideSpecialPages ) {
 			$hidePages = array( 'Recentchangeslinked', 'Recentchanges', 'Listredirects', 'Mostlinkedcategories', 'Export', 'Uncategorizedtemplates', 
 				'DoubleRedirects', 'DeletedContributions', 'Mostcategories', 'Block', 'Movepage', 'Mostrevisions', 'Unusedimages', 'Log', 
@@ -90,7 +90,7 @@ class LoopHooks {
 				'MyLanguage', 'Mypage', 'Mytalk', 'Myuploads', 'AllMyUploads', 'PermanentLink', 'Redirect', 'RunJobs', 'PageData', 'ChangeContentModel', 
 				'MathStatus', 'RevisionReview', 'ReviewedVersions', 'BotPasswords', 'LinkAccounts', 'UnlinkAccounts', 'RemoveCredentials',
 				'PendingChanges', 'ProblemChanges', 'ReviewedPages', 'UnreviewedPages', 'QualityOversight', 'ValidationStatistics', 'ConfiguredPages',
-				'LoopLiteratureEdit', 'LoopLiteratureImport', 'LoopLiteratureExport', 'LoopTerminologyEdit'
+				'LoopLiteratureEdit', 'LoopLiteratureImport', 'LoopLiteratureExport', 'LoopTerminologyEdit', 'NewSection', 'LoopFeedback'
 			);
 			foreach( $hidePages as $page ){ 
 				unset( $specialPages[$page] );

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -213,6 +213,18 @@ class Loop {
 	 * @param string $text
 	 */
 	public static function setReferenceIds( $text ) { #todo remove id and type
+
+		# REGEX: All tags to get IDs that don't have id="" or id='' (might be empty!)
+		$regex = '/(<(loop_figure|loop_formula|loop_listing|loop_media|loop_table|loop_task|cite|loop_index|loop_screenshot)(?!.*?id=([\'"]).*?([\'"]))[^>]*)(>)/i';
+		preg_match_all( $regex, $text, $occurences );
+		$count = sizeof($occurences[1]);
+		$tmpText = $text;
+		for ( $i = 0; $i <= $count; $i++ ) {
+			$tmpText = preg_replace( $regex, '$1 id="'.uniqid().'">', $tmpText, 1 );
+		}
+		return $tmpText;
+		#dd($text, $tmpText, $occurences, $count);
+		/*
 		$changedText = false;
 		$tmptext = mb_convert_encoding("<?xml version='1.0' encoding='utf-8'?>\n<div>" .$text.'</div>', 'HTML-ENTITIES', 'UTF-8');
 		$forbiddenTags = array( 'nowiki', 'code', '!--', 'syntaxhighlight', 'source'); # don't set ids when in these tags 
@@ -225,24 +237,26 @@ class Loop {
 		
 		$query = implode(' | ', $objectTags);
 		$nodes = $xpath->query( $query );
-		$changed = false;
+		$change = array();
 		foreach ( $nodes as $node ) {
 			# don't set ids when in these tags 
 			if ( ! in_array( strtolower($node->parentNode->nodeName), $forbiddenTags ) && ! in_array( strtolower($node->parentNode->parentNode->nodeName), $forbiddenTags ) ) {
 				$existingId = $node->getAttribute( 'id' );
 				if( ! $existingId ) {
-					$node->setAttribute('id', uniqid() );
-					$changed = true;
+					$change[$node->nodeName] = uniqid();
 				}
 			}
 		}
-		if ( $changed ) {
-			$changedText = mb_substr($dom->saveHTML(), 55, -21);
-			$decodedText = html_entity_decode($changedText);
+		if ( !empty ( $change ) ) {
+			dd($change);
+			#$changedText = mb_substr($dom->saveHTML(), 55, -21);
+			#$decodedText = html_entity_decode($changedText);
 			return $decodedText;
 		} else {
 			return $text;
 		}
+		*/
+
 	}
 
 }

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -43,10 +43,6 @@ class Loop {
 		
 	public static function onExtensionLoad() {
 
-		if ( ! defined( 'FLAGGED_REVISIONS' ) ) { 
-			exit( "FlaggedRevs must be installed to run LOOP" );
-		}
-
 		# Loop Object constants
 		define('LOOPOBJECTNUMBER_MARKER_PREFIX', "\x7fUNIQ--loopobjectnumber-");
 		define('LOOPOBJECTNUMBER_MARKER_SUFFIX', "-QINU\x7f");
@@ -112,11 +108,11 @@ class Loop {
 				$wgLoopFeedbackLevel = ( !isset( $data['lset_feedbacklevel'] ) ? $wgLoopFeedbackLevel : $data['lset_feedbacklevel'] );
 				$wgLoopFeedbackMode = ( !isset( $data['lset_feedbackmode'] ) ? $wgLoopFeedbackMode : $data['lset_feedbackmode'] );
 			}
-			
-			# Define new name for glossary
-			$wgExtraNamespaces[ NS_GLOSSARY ] = wfMessage( "loop-glossary-namespace" )->inLanguage( $wgLanguageCode )->text();
 
 		}
+			
+		# Define new name for glossary
+		$wgExtraNamespaces[ NS_GLOSSARY ] = wfMessage( "loop-glossary-namespace" )->inLanguage( $wgLanguageCode )->text();
 
 		$wgWhitelistRead[] = $wgLoopImprintLink;
 		$wgWhitelistRead[] = $wgLoopPrivacyLink;
@@ -136,7 +132,7 @@ class Loop {
 		$wgFlaggedRevsAutopromote = false;
 		$wgShowRevisionBlock = false;
 		$wgSimpleFlaggedRevsUI = false;
-		$wgFlaggedRevsAutoReview = FR_AUTOREVIEW_CREATION_AND_CHANGES;
+		$wgFlaggedRevsAutoReview = 3; # FR_AUTOREVIEW_CREATION_AND_CHANGES
 		$wgFlaggedRevsNamespaces[] = NS_GLOSSARY; #adds Glossary to reviewing process
 
 		# Log viewing rights

--- a/includes/LoopFeedbackApi.php
+++ b/includes/LoopFeedbackApi.php
@@ -20,7 +20,7 @@ class ApiLoopFeedbackSave extends ApiBase {
 		$result   = $this->getResult();
 		
 		$user = $this->getUser();
-		if ( $user->isBlocked() ) {
+		if ( $user->getBlock() != null ) {
 			$this->dieWithError(
 				$this->msg( 'loopfeedback-error-blocked' )->escaped(),
 				'userblocked'
@@ -168,7 +168,7 @@ class ApiLoopFeedbackStructure extends ApiBase {
 		
 
 		$user = $this->getUser();
-		if ( $user->isBlocked() ) {
+		if ( $user->getBlock() != null ) {
 			$this->dieWithError(
 				$this->msg( 'loopfeedback-error-blocked' )->escaped(),
 				'userblocked'
@@ -266,7 +266,7 @@ class ApiLoopFeedbackPageDetails extends ApiBase {
 		
 
 		$user = $this->getUser();
-		if ( $user->isBlocked() ) {
+		if ( $user->getBlock() != null ) {
 			$this->dieWithError(
 				$this->msg( 'loopfeedback-error-blocked' )->escaped(),
 				'userblocked'
@@ -406,7 +406,7 @@ class ApiLoopFeedbackOverview extends ApiBase {
 		$result   = $this->getResult();
 		
 		$user = $this->getUser();
-		if ( $user->isBlocked() ) {
+		if ( $user->getBlock() != null ) {
 			$this->dieWithError(
 				$this->msg( 'loopfeedback-error-blocked' )->escaped(),
 				'userblocked'

--- a/includes/LoopFigure.php
+++ b/includes/LoopFigure.php
@@ -78,11 +78,10 @@ class LoopFigure extends LoopObject{
 	
 	/**
 	 * Parse the given Parameters and subtags
-	 * @param bool $fullparse
 	 */
-	public function parse($fullparse = false) {
+	public function parse() {
 
-		$this->preParse($fullparse);
+		$this->preParse();
 		
 		$matches = array ();
 		$subtags = array (
@@ -95,18 +94,10 @@ class LoopFigure extends LoopObject{
 		foreach ( $matches as $marker => $subtag ) {
 			switch ($subtag [0]) {
 				case 'loop_figure_title' :
-					if ($fullparse == true) {
-						$this->setTitleFullyParsed($this->extraParse( $subtag [1] ), false);
-					} else {
-						$this->setTitle($this->mParser->stripOuterParagraph ( $this->getParser()->recursiveTagParse ( $subtag [1] ) ));
-					}
+					$this->setTitle($this->mParser->stripOuterParagraph ( $this->getParser()->recursiveTagParse ( $subtag [1] ) ));
 					break;
 				case 'loop_figure_description' :
-					if ($fullparse == true) {
-						$this->setDescriptionFullyParsed($this->extraParse( $subtag [1] ), false);
-					} else {
-						$this->setDescription($this->mParser->stripOuterParagraph ( $this->getParser()->recursiveTagParse ( $subtag [1] ) ));
-					}
+					$this->setDescription($this->mParser->stripOuterParagraph ( $this->getParser()->recursiveTagParse ( $subtag [1] ) ));
 					break;
 			}
 		}
@@ -181,19 +172,11 @@ class LoopFigure extends LoopObject{
 				$numberText = " " . LoopObject::getObjectNumberingOutput( $this->mId, $pageData, $previousObjects);
 			}
 		}
-		$outputTitle = '';
-
-		if ( $this->getTitleFullyParsed() ) {
-			$outputTitle = $this->getTitleFullyParsed();
-		} elseif ( $this->getTitle() ) {
-			$outputTitle = $this->getTitle();
-		}
+		
 		$html .= '<td scope="col" class="pl-1 pr-1"><span class="font-weight-bold">'. wfMessage ( $this->getTag().'-name-short' )->inContentLanguage ()->text () . $numberText . ': ' . '</span></td>';
-		$html .= '<td scope="col" class=" "><span class="font-weight-bold">'. preg_replace ( '!(<br)( )?(\/)?(>)!', ' ', $outputTitle ) . '</span><br/><span>';
-	
-		if ($this->mDescriptionFullyParsed) {
-			$html .= preg_replace ( '!(<br)( )?(\/)?(>)!', ' ', $this->getDescriptionFullyParsed() ) . '<br/>';
-		} elseif ($this->mDescription) {
+		$html .= '<td scope="col" class=" "><span class="font-weight-bold">'. preg_replace ( '!(<br)( )?(\/)?(>)!', ' ', LoopObject::localParse( $this->getTitle() ) ) . '</span><br/><span>';
+		if ( strpos( $this->getTitle(), "<math>") !== false){dd($this->getTitle(), LoopObject::localParse( $this->getTitle() ));}
+		if ($this->mDescription) {
 			$html .= preg_replace ( '!(<br)( )?(\/)?(>)!', ' ', $this->getDescription() ) . '<br/>';
 		} 
 		$linkTitle = Title::newFromID ( $this->getArticleId () );

--- a/includes/LoopIndex.php
+++ b/includes/LoopIndex.php
@@ -35,7 +35,7 @@ class LoopIndex {
 			# check if a dublicate id has been used
 			if ( $input != $item->li_index || $articleId != $item->li_pageid ) { 
 				$otherTitle = Title::newFromId( $item->li_pageid );
-				$e = new LoopException( wfMessage( 'loopindex-error-dublicate-id', $id, $otherTitle->mTextform, $item->li_index ) );
+				$e = new LoopException( wfMessage( 'loopindex-error-dublicate-id', $id, $otherTitle->mTextform, $item->li_index )->text() );
 				$parser->addTrackingCategory( 'loop-tracking-category-error' );
 				$html .= $e . "\n";
 			}

--- a/includes/LoopLiterature.php
+++ b/includes/LoopLiterature.php
@@ -540,7 +540,7 @@ class LoopLiterature {
 
 				if ( $refId != $allReferences[$articleId][$refId]["refId"] || $articleId != $allReferences[$articleId][$refId]["articleId"] || $input != $allReferences[$articleId][$refId]["itemKey"] ) {
 					$otherTitle = Title::newFromId( $allReferences[$articleId][$refId]["articleId"] );
-					$e = new LoopException( wfMessage( 'loopliterature-error-dublicate-id', $refId, $otherTitle->mTextform, $allReferences[$articleId][$refId]["itemKey"] ) );
+					$e = new LoopException( wfMessage( 'loopliterature-error-dublicate-id', $refId, $otherTitle->mTextform, $allReferences[$articleId][$refId]["itemKey"] )->text() );
 					$parser->addTrackingCategory( 'loop-tracking-category-error' );
 					$html .= $e;
 					$objectNumber = '';

--- a/includes/LoopMedia.php
+++ b/includes/LoopMedia.php
@@ -114,7 +114,7 @@ class LoopMedia extends LoopObject{
 		
 		if ( ! in_array ( $this->getMediaType(), self::$mMediaTypes ) ) {
 			$this->setMediaType('media');
-			$e = new LoopException( wfMessage( 'loopmedia-error-unknown-mediatype', $mediatype, implode( ', ',self::$mMediaTypes ) ) );
+			$e = new LoopException( wfMessage( 'loopmedia-error-unknown-mediatype', $mediatype, implode( ', ',self::$mMediaTypes ) )->text() );
 			$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 			$this->error = $e;
 		}		

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -842,47 +842,51 @@ class LoopObject {
 				$parser->extractTagsAndParams( $extractTags, $contentText, $object_tags );
 				$newContentText = $contentText;
 
-				foreach ( $object_tags as $object ) {
-					if ( ! in_array( strtolower($object[0]), $forbiddenTags ) ) { #exclude loop-tags that are in code or nowiki tags
-						if ( ( ! isset ( $object[2]["index"] ) || $object[2]["index"] != strtolower("false") ) && isset( $objects[$object[0]] ) ) {
-							$valid = true;
-							$tmpLoopObjectIndex = new LoopObjectIndex();
-							$objects[$object[0]]++;
-							$tmpLoopObjectIndex->nthItem = $objects[$object[0]];
-							$tmpLoopObjectIndex->index = $object[0];
-							$tmpLoopObjectIndex->pageId = $title->getArticleID();
-							
-							if ( $object[0] == "loop_figure" ) {
-								preg_match('/(.*)(\[\[.*\]\])(.*)/U', $object[1], $thumb);
-								$tmpLoopObjectIndex->itemThumb = array_key_exists( 2, $thumb ) ? $thumb[2] : null;
-							}
-							if ( $object[0] == "loop_media" && isset( $object[2]["type"] ) ) {
-								$tmpLoopObjectIndex->itemType = $object[2]["type"];
-							}
-							if ( isset( $object[2]["title"] ) ) {
-								$tmpLoopObjectIndex->itemTitle = $object[2]["title"];
-							} else {
-								$title_tags = array ();
-								$parser->extractTagsAndParams( ["loop_title", "loop_figure_title"], $object[1], $title_tags );
-								foreach( $title_tags as $tag ) {
-									$tmpLoopObjectIndex->itemTitle = $tag[1];
-									break;
+				foreach ( $object_tags as $outter_object ) {
+					if ( ! in_array( strtolower($outter_object[0]), $forbiddenTags ) ) { #exclude loop-tags that are in code or nowiki tags
+						$parser->extractTagsAndParams( $extractTags, $outter_object[1], $items );
+						$items[] = $outter_object;
+						foreach ( $items as $object) {
+							if ( ( ! isset ( $object[2]["index"] ) || $object[2]["index"] != strtolower("false") ) && isset( $objects[$object[0]] ) ) {
+								$valid = true;
+								$tmpLoopObjectIndex = new LoopObjectIndex();
+								$objects[$object[0]]++;
+								$tmpLoopObjectIndex->nthItem = $objects[$object[0]];
+								$tmpLoopObjectIndex->index = $object[0];
+								$tmpLoopObjectIndex->pageId = $title->getArticleID();
+								
+								if ( $object[0] == "loop_figure" ) {
+									preg_match('/(.*)(\[\[.*\]\])(.*)/U', $object[1], $thumb);
+									$tmpLoopObjectIndex->itemThumb = array_key_exists( 2, $thumb ) ? $thumb[2] : null;
 								}
-							}
-							if ( isset( $object[2]["description"] ) ) {
-								$tmpLoopObjectIndex->itemDescription = $object[2]["description"];
-							}
-							if ( isset( $object[2]["id"] ) ) {
-								if ( $tmpLoopObjectIndex->checkDublicates( $object[2]["id"] ) ) {
-									$tmpLoopObjectIndex->refId = $object[2]["id"];
+								if ( $object[0] == "loop_media" && isset( $object[2]["type"] ) ) {
+									$tmpLoopObjectIndex->itemType = $object[2]["type"];
+								}
+								if ( isset( $object[2]["title"] ) ) {
+									$tmpLoopObjectIndex->itemTitle = $object[2]["title"];
 								} else {
-									# dublicate id!
-									$valid = false;
-									$objects[$object[0]]--;
+									$title_tags = array ();
+									$parser->extractTagsAndParams( ["loop_title", "loop_figure_title"], $object[1], $title_tags );
+									foreach( $title_tags as $tag ) {
+										$tmpLoopObjectIndex->itemTitle = $tag[1];
+										break;
+									}
 								}
-							} 
-							if ( $valid && $stable && ( ! isset ( $object[2]["index"] ) || strtolower($object[2]["index"]) != "false" ) && ( ! isset ( $object[2]["render"] ) || strtolower($object[2]["render"]) != "none" ) ) {
-								$tmpLoopObjectIndex->addToDatabase();
+								if ( isset( $object[2]["description"] ) ) {
+									$tmpLoopObjectIndex->itemDescription = $object[2]["description"];
+								}
+								if ( isset( $object[2]["id"] ) ) {
+									if ( $tmpLoopObjectIndex->checkDublicates( $object[2]["id"] ) ) {
+										$tmpLoopObjectIndex->refId = $object[2]["id"];
+									} else {
+										# dublicate id!
+										$valid = false;
+										$objects[$object[0]]--;
+									}
+								} 
+								if ( $valid && $stable && ( ! isset ( $object[2]["index"] ) || strtolower($object[2]["index"]) != "false" ) && ( ! isset ( $object[2]["render"] ) || strtolower($object[2]["render"]) != "none" ) ) {
+									$tmpLoopObjectIndex->addToDatabase();
+								}
 							}
 						}
 					}

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -840,7 +840,6 @@ class LoopObject {
 				$forbiddenTags = array( 'nowiki', 'code', '!--', 'syntaxhighlight', 'source' ); # don't save ids when in here
 				$extractTags = array_merge( self::$mObjectTypes, $forbiddenTags );
 				$parser->extractTagsAndParams( $extractTags, $contentText, $object_tags );
-				$newContentText = $contentText;
 
 				foreach ( $object_tags as $outter_object ) {
 					if ( ! in_array( strtolower($outter_object[0]), $forbiddenTags ) ) { #exclude loop-tags that are in code or nowiki tags
@@ -883,7 +882,9 @@ class LoopObject {
 										$valid = false;
 										$objects[$object[0]]--;
 									}
-								} 
+								} else {
+									$valid = false;
+								}
 								if ( $valid && $stable && ( ! isset ( $object[2]["index"] ) || strtolower($object[2]["index"]) != "false" ) && ( ! isset ( $object[2]["render"] ) || strtolower($object[2]["render"]) != "none" ) ) {
 									$tmpLoopObjectIndex->addToDatabase();
 								}
@@ -898,12 +899,9 @@ class LoopObject {
 				} elseif ( $title->getNamespace() == NS_GLOSSARY ) {
 					LoopGlossary::updateGlossaryPageTouched();
 				}
-				if ( $contentText !== $newContentText ) {
-					return $newContentText;
-				}
 			}
 		}
-		return $contentText;
+		return true;
 	}
 
 
@@ -1061,6 +1059,7 @@ class LoopObject {
 		}
 
 		if ( $objectData["refId"] == $objectid ) {
+			$tmpPreviousObjects = 0;
 
 			if ( $wgLoopNumberingType == "chapter" && $typeOfPage == "structure" ) {
 					
@@ -1076,11 +1075,10 @@ class LoopObject {
 				}
 				if ( isset($previousObjects[$objectData["index"]]) ) {
 					$tmpPreviousObjects = $previousObjects[$objectData["index"]];
-				}
+				} 
 				return $tocChapter . "." . ( $tmpPreviousObjects + $objectData["nthoftype"] );
 				
 			} elseif ( $wgLoopNumberingType == "ongoing" || $typeOfPage == "glossary" ) {
-				$tmpPreviousObjects = 0;
 				if ( isset($previousObjects[$objectData["index"]]) ) {
 					$tmpPreviousObjects = $previousObjects[$objectData["index"]];
 				}

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -193,7 +193,7 @@ class LoopObject {
 				if ( is_object( $otherTitle ) ) {
 					$textform = $otherTitle->mTextform;
 				}
-				$e = new LoopException( wfMessage( 'loopobject-error-dublicate-id', $this->getId(), $textform ) );
+				$e = new LoopException( wfMessage( 'loopobject-error-dublicate-id', $this->getId(), $textform )->text() );
 				$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 				$this->error .= $e . "\n";
 				$showNumbering = false;

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -938,7 +938,8 @@ class LoopObject {
 							$tmpLoopObjectIndex->pageId = $title->getArticleID();
 							
 							if ( $object[0] == "loop_figure" ) {
-								$tmpLoopObjectIndex->itemThumb = $object[1];
+								preg_match('/(.*)(\[\[.*\]\])(.*)/U', $object[1], $thumb);
+								$tmpLoopObjectIndex->itemThumb = array_key_exists( 2, $thumb ) ? $thumb[2] : null;
 							}
 							if ( $object[0] == "loop_media" && isset( $object[2]["type"] ) ) {
 								$tmpLoopObjectIndex->itemType = $object[2]["type"];

--- a/includes/LoopSpoiler.php
+++ b/includes/LoopSpoiler.php
@@ -111,7 +111,7 @@ class LoopSpoiler {
 		
 		// throw exception if spoiler type is not valid
 		if ( !empty( $spoiler->getType() ) && !in_array ( $spoiler->getType(), self::$mSpoilerTypes ) ) {
-			throw new LoopException( wfMessage ( 'loopspoiler-error-unknown-spoilertype', $spoiler->getType(), implode ( ', ', self::$mSpoilerTypes ) ) );
+			throw new LoopException( wfMessage ( 'loopspoiler-error-unknown-spoilertype', $spoiler->getType(), implode ( ', ', self::$mSpoilerTypes ) )->text() );
 		}		
 		
 		// button text


### PR DESCRIPTION
- Upgrade zu MW 1.34 
UserRights zur Abfrage von Spezialseiten geändert
Neue Spezialseiten blockiert
Extensions aktualisiert
Deprecated User->isBlocked Funktion ersetzt
Glossar-Messages machten Probleme nach dem Upgrade
FlaggedRevs hat jetzt extension.json
- Behebt Mathe-Parser Fehler bei Exceptions 
- Behebt Mathe-Parser Fehler bei loop_title-Tags (Parsen wird jetzt auf der Seite selber durchgeführt, auch im Verzeichnis)
- Beim ID-Setzen werden keine anderen Teile des Inhalts mehr verändert. Todo: innerhalb von zb nowiki werden zzt noch IDs gesetzt, das muss geändert werden.