### PR TITLE
Fixes und Align

### DIFF
--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -213,6 +213,8 @@ class LoopExportPdf extends LoopExport {
 		header("Content-Type: application/pdf");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2117,7 +2117,7 @@
 	<xsl:template match="extension" mode="loop_accordion">
 		<xsl:choose>
 			<xsl:when test="@extension_name='loop_title'">
-				<fo:block>
+				<fo:block font-weight="bold">
 					<xsl:apply-templates></xsl:apply-templates>
 				</fo:block>
 			</xsl:when>


### PR DESCRIPTION
- Versionsgeschichte-Page hat etwas mehr Abstände
- Aligns der Bilder mit oder ohne loop_object funktioniert nun (siehe Oldenburgs Startseite)
- mobile fixes
- Accordion-Title im PDF bold