### PR TITLE
Fixes zu Betatests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 	"require" : {
 		"composer/installers" : "1.*,>=1.0.1",
 		"james-heinrich/getid3" : ">=1.9",
-		"symfony/process" : ">=4.3.2",
 		"renanbr/bibtex-parser" : ">=2.0.2",
 		"ryakad/pandoc-php" : "~1.0"
 	}

--- a/extension.json
+++ b/extension.json
@@ -315,7 +315,9 @@
 				"loopwikieditor-loop-content-prezi",
 				"loopwikieditor-loop-content-slideshare",
 				"loopwikieditor-loop-content-quizlet",
-				"loopscreenshot"
+				"loopscreenshot",
+				"loopwikieditor-loop-snippets-accordion",
+				"loopwikieditor-loop-snippets-syntaxhighlight"
 			]
 		},
 		"loop.feedback.js": {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -378,6 +378,8 @@
 	"loopwikieditor-loop-snippets-sidenote": "Marginalie",
 	"loopwikieditor-loop-snippets-print": "Druckbereich",
 	"loopwikieditor-loop-snippets-noprint": "Nicht-Druckbereich",
+	"loopwikieditor-loop-snippets-accordion": "Akkordeon",
+	"loopwikieditor-loop-snippets-syntaxhighlight": "Syntaxhighlighted Code",
 	"loopwikieditor-loop-contents": "Medien",
 	"loopwikieditor-loop-content-audio": "lokale Audiodatei",
 	"loopwikieditor-loop-content-video": "lokales Video",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -378,6 +378,8 @@
 	"loopwikieditor-loop-snippets-sidenote": "Marginalie",
 	"loopwikieditor-loop-snippets-print": "Print area",
 	"loopwikieditor-loop-snippets-noprint": "No-print area",
+	"loopwikieditor-loop-snippets-accordion": "Accordion",
+	"loopwikieditor-loop-snippets-syntaxhighlight": "Syntaxhighlighted code",
 	"loopwikieditor-loop-contents": "Media",
 	"loopwikieditor-loop-content-audio": "local audio",
 	"loopwikieditor-loop-content-video": "local video",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -368,6 +368,8 @@
 	"loopwikieditor-loop-snippets-sidenote": "Nota marginal",
 	"loopwikieditor-loop-snippets-print": "Área de impresión",
 	"loopwikieditor-loop-snippets-noprint": "Área no imprimible",
+	"loopwikieditor-loop-snippets-accordion": "Acordeón",
+	"loopwikieditor-loop-snippets-syntaxhighlight": "Código resaltado de sintaxis",
 	"loopwikieditor-loop-contents": "Multimedia",
 	"loopwikieditor-loop-content-audio": "Audio local",
 	"loopwikieditor-loop-content-video": "Video local",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -378,6 +378,8 @@
 	"loopwikieditor-loop-snippets-sidenote": "Wikieditor LOOP : Template Marginalie",
 	"loopwikieditor-loop-snippets-print": "Wikieditor LOOP : Template Print area",
 	"loopwikieditor-loop-snippets-noprint": "Wikieditor LOOP : Template No-print area",
+	"loopwikieditor-loop-snippets-accordion": "Wikieditor LOOP : Template accordion",
+	"loopwikieditor-loop-snippets-syntaxhighlight": "Wikieditor LOOP : Template Syntaxhighlighted code",
 	"loopwikieditor-loop-contents": "Wikieditor LOOP section: Label for dropdown - Media",
 	"loopwikieditor-loop-content-audio": "Wikieditor LOOP: Media local audio",
 	"loopwikieditor-loop-content-video": "Wikieditor LOOP: Media local video",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -378,6 +378,8 @@
 	"loopwikieditor-loop-snippets-sidenote": "Marginalie",
 	"loopwikieditor-loop-snippets-print": "Printavsnitt",
 	"loopwikieditor-loop-snippets-noprint": "No-Printavsnitt",
+	"loopwikieditor-loop-snippets-accordion": "Accordeon",
+	"loopwikieditor-loop-snippets-syntaxhighlight": "Syntaxhighlighted code",
 	"loopwikieditor-loop-contents": "Medier",
 	"loopwikieditor-loop-content-audio": "lokalt audio",
 	"loopwikieditor-loop-content-video": "lokalt video",

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -873,6 +873,13 @@ class LoopObject {
 								}
 								if ( isset( $object[2]["description"] ) ) {
 									$tmpLoopObjectIndex->itemDescription = $object[2]["description"];
+								} else {
+									$desc_tags = array ();
+									$parser->extractTagsAndParams( ["loop_description", "loop_figure_description"], $object[1], $desc_tags );
+									foreach( $desc_tags as $tag ) {
+										$tmpLoopObjectIndex->itemDescription = $tag[1];
+										break;
+									}
 								}
 								if ( isset( $object[2]["id"] ) ) {
 									if ( $tmpLoopObjectIndex->checkDublicates( $object[2]["id"] ) ) {

--- a/includes/LoopUpdater.php
+++ b/includes/LoopUpdater.php
@@ -38,7 +38,7 @@ class LoopUpdater {
 			Loop::setupLoopPages();
 		}
 		# LOOP1 to LOOP2 migration process #LOOP1UPGRADE
-		if ( $updater->tableExists( 'loop_object_index' ) && $updater->tableExists( 'loopstructure' )  ) { #sonst bricht der updater ab. updater muss so jetzt zweimal laufen #todo
+		if ( $updater->tableExists( 'loop_structure_items' ) && $updater->tableExists( 'loopstructure' )  ) { #sonst bricht der updater ab. updater muss so jetzt zweimal laufen #todo
 			
 			if ( isset( $wgLoopAddToSettingsDB ) ) { # update settings DB from LocalSettings
 				if ( !empty( $wgLoopAddToSettingsDB )) {
@@ -46,6 +46,7 @@ class LoopUpdater {
 				}
 			}
 
+			$updater->addExtensionUpdate(array( 'modifyTable', 'loop_structure_items', $schemaPath . 'loop_structure_items_modify.sql', true ) );
 			$updater->addExtensionUpdate(array( 'dropTable', 'loopstructure', $schemaPath . 'loopstructure_delete.sql', true ) );
 
 			self::saveAllWikiPages();

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -296,18 +296,28 @@ class LoopXml {
 				$child_name='text';
 				$child_value=$child->textContent;
 			}
-	
+			
+			$leftright = array(
+				"right" => "right",
+				"left" => "left",
+				"center" => "center",
+				"rechts" => "right",
+				"links" => "left",
+				"zentriert" => "center",
+			);
+
 			if ($child_name == 'part') {
 				if (substr($child_value, -2) == 'px') {
 					$child_name = 'width';
 					$child_value = substr($child_value,0,-2);
-				} elseif (($child_value == 'right') || ($child_value == 'left') || ($child_value == 'center')) {
+				} elseif ( array_key_exists( $child_value, $leftright ) ) {
 					$child_name = 'align';
-	
+					$child_value = $leftright[ $child_value ];
 				}
 			}
-			$link_parts[$child_name]=$child_value;
+			$link_parts[$child_name] = $child_value;
 		}
+		
 		if (!array_key_exists('type', $link_parts)) {
 			$link_parts['type']='internal';
 		}
@@ -404,6 +414,7 @@ class LoopXml {
 				}
 			}
 		}
+		#dd($return_xml, $link_parts);
 		$return = new DOMDocument;
 	
 		$old_error_handler = set_error_handler("LoopXml::error_handler");

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -737,7 +737,7 @@ class wiki2xml
 			if ( !$this->nextis ( $b , "|" ) ) return false ;
 			if ( !$this->p_internal_link_text ( $b , $x , false , "]]" ) ) return false ;
 		}
-		$this->p_internal_link_trail ( $b , $x ) ;
+		#$this->p_internal_link_trail ( $b , $x ) ; # LOOP: [[file:bildname.png]]Wort kein Leerzeichen zwischen ]] und Wort hat das Wort aus der PDF einfach entfernt.
 		$xml .= "<link>{$x}</link>" ;
 		$a = $b ;
 		return true ;

--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -9,6 +9,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
     die( "This file cannot be run standalone.\n" );
 }
 
+use MediaWiki\Shell\Shell;
 class LoopXsl {
 
 	/**
@@ -147,93 +148,89 @@ class LoopXsl {
 		
 		global $wgPygmentizePath, $IP, $wgScriptPath;
 		
-		$symfonyPath = "$IP/extensions/Loop/vendor/symfony/process/";
-
-		if ( is_file( $symfonyPath . "Process.php" ) ) {
+		$return = '';
+		$input_object=$input[0];
 		
-			$return = '';
-			$input_object=$input[0];
-			
-			$dom = new DOMDocument( "1.0", "utf-8" );
-			$dom->appendChild($dom->importNode($input_object, true));
-			$xml = $dom->saveXML();
+		$dom = new DOMDocument( "1.0", "utf-8" );
+		$dom->appendChild($dom->importNode($input_object, true));
+		$xml = $dom->saveXML();
 
-			$xml = str_replace('<space/>',' ',$xml);
-			$xml = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $xml); 
-			$xml = preg_replace("/^(<extension)(.*)(>)/", "", $xml);
-			$xml = preg_replace("/(<\/extension>)$/", "", $xml);
-			$xml = trim ($xml, " \n\r");
+		$xml = str_replace('<space/>',' ',$xml);
+		$xml = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $xml); 
+		$xml = preg_replace("/^(<extension)(.*)(>)/U", "", $xml);
+		$xml = preg_replace("/(<\/extension>)$/U", "", $xml);
+		$xml = trim ($xml, " \n\r");
 
-			$xml = htmlspecialchars_decode ($xml);
+		$xml = htmlspecialchars_decode ($xml);
 
-			$code = $xml;
+		$code = $xml;
 		
-			require_once $symfonyPath . "Process.php";
-			require_once $symfonyPath . "ProcessUtils.php";
-			require_once $symfonyPath . "Pipes/PipesInterface.php";
-			require_once $symfonyPath . "Pipes/AbstractPipes.php";
-			require_once $symfonyPath . "Pipes/UnixPipes.php";
-			
-			
-			if ($input_object->hasAttribute('lang')) {
-				$lexer = $input_object->getAttribute('lang');
-				$lang = $input_object->getAttribute('lang');
-			} else {
-				$lexer = 'xml';
-			}
-			# doc for command: http://pygments.org/docs/formatters/#HtmlFormatter
-			$command = array( "-l", $lexer, "-O", "linenos=inline" ); # defines lexer (language to highlight in)
-
-			# we ignore the 'inline' attribute as we need to have line breaks on paper
-
-			/* 	# as standard, line numbers should be shown! 
-				# because line-breaking is mandatory, line numbers indicate actual new lines so users can tell the difference
-			if ($input_object->hasAttribute('line')) {
-				$line = $input_object->getAttribute('line');
-				$command[] = "-O";
-				$command[] = "linenos=inline";
-			} */
-			if ($input_object->hasAttribute('start') ) { # defines the start option of line numbering
-				$start = $input_object->getAttribute('start');
-				$command[] = "-O";
-				$command[] = "linenostart=" . $start;
-			}
-			if ($input_object->hasAttribute('highlight')) { # highlights given lines
-				$highlight = $input_object->getAttribute('highlight');
-				$command[] = "-O";
-				$command[] = "hl_lines=$highlight";
-			}
-
-			$command = array_merge ( [ $wgPygmentizePath, "-f", "html", "-O", "encoding=utf-8", "-O", "cssclass", "-O", "startinline=true" ], $command );
-
-			$process = new Symfony\Component\Process\Process( $command, null, null, $code );
-			$process->run();
-			
-			if ( !$process->isSuccessful() ) {
-				$output ='';
-			} else {
-				$output = $process->getOutput();
-			}
-			#var_dump($output); dd($output, $xml,$lexer, $code, $process);
-
-			$output = '<pre>'.$output.'</pre>';
-			$return = new DOMDocument;
-			
-			$old_error_handler = set_error_handler("LoopXsl::xsl_error_handler");
-			libxml_use_internal_errors(true);
-			
-			try {
-				$return->loadXml($output);
-			} catch ( Exception $e ) {
-			
-			}
-			restore_error_handler();	
-
-			return $return;
+		if ($input_object->hasAttribute('lang')) {
+			$lexer = $input_object->getAttribute('lang');
+			$lang = $lexer;
 		} else {
-			# if symfony/process is not present, just return the input node
-			return $input[0];
+			$lexer = 'xml';
 		}
+		# doc for command: http://pygments.org/docs/formatters/#HtmlFormatter
+		#$command = array( "-l", $lexer ); # defines lexer (language to highlight in)
+
+		# we ignore the 'inline' attribute as we need to have line breaks on paper
+
+		$options = "encoding=utf-8,cssclass=mw-highlight";
+
+		# pdf line numbers are mandatory
+		#if ($input_object->hasAttribute('line')) {
+		#	$line = $input_object->getAttribute('line');
+		$options .= ",linenos=inline";
+		#} 
+		if ($input_object->hasAttribute('start') ) { # defines the start option of line numbering
+			$start = $input_object->getAttribute('start');
+			$options .= ",linenostart=" . $start;
+		}
+		if ($input_object->hasAttribute('highlight')) { # highlights given lines
+			$highlight = $input_object->getAttribute('highlight');
+			$options .= ",hl_lines=$highlight";
+		}
+		if ( $lexer === 'php' && strpos( $code, '<?php' ) === false ) { 
+			$options .= ",startinline=true";
+		} 
+
+		$command = [ "-l", $lexer, "-f", "html", "-O", $options ];
+		
+		$result = Shell::command(
+			$wgPygmentizePath,
+			'-l', $lexer,
+			'-f', 'html',
+			'-O',implode( ' ', $command )
+		)
+			->input( $code )
+			->restrict( Shell::RESTRICT_DEFAULT | Shell::NO_NETWORK )
+			->execute();
+
+		if ( $result->getExitCode() != 0 ) {
+			$output ='';
+		}
+
+		if ( $result->getExitCode() != 0 ) {
+			$output ='';
+		} else {
+			$output = $result->getStdout();
+		}
+
+		$output = '<pre>'.$output.'</pre>';
+		$return = new DOMDocument;
+		$old_error_handler = set_error_handler("LoopXsl::xsl_error_handler");
+		libxml_use_internal_errors(true);
+		
+		try {
+			$return->loadXml($output);
+		} catch ( Exception $e ) {
+		
+		}
+		restore_error_handler();	
+
+		return $return;
+		
 		
 	}
 
@@ -253,7 +250,7 @@ class LoopXsl {
 		
 		$xml = $dom->saveXML();
 		$xml = str_replace('<space/>', ' ',$xml);
-		$xml = preg_replace("/(\s\\t)/","\n\t", $xml);
+		$xml = preg_replace("/(\s\\t)/"," \t", $xml);
 		
 		$dom2 = new DOMDocument( "1.0", "utf-8" );
 		$dom2->loadXML($xml);

--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -172,8 +172,8 @@ class LoopXsl {
 			$lang = $input_object->getAttribute('lang');
 			$lexers = require $wgExtensionDirectory . '/SyntaxHighlight_GeSHi/SyntaxHighlight.lexers.php';
 			$lexer = strtolower( $lang );
-			if ( array_key_exists( $lexers[$lexer] ) ) {
-				return $lexer;
+			if ( array_key_exists( $lexer, $lexers ) ) {
+				$lexer = $lexer;
 			} else {
 				$geshi2pygments = SyntaxHighlightGeSHiCompat::getGeSHiToPygmentsMap();
 	

--- a/resources/js/loop.wikiEditor.js
+++ b/resources/js/loop.wikiEditor.js
@@ -587,6 +587,28 @@ var customizeWikiEditor = function () {
                                             }
                                         }
                                     },
+                                    'loopsnippets-syntaxhighlight': {
+                                        labelMsg: 'loopwikieditor-loop-snippets-syntaxhighlight',
+                                        action: {
+                                            type: 'encapsulate',
+                                            options: {
+                                                pre: '<syntaxhighlight lang="xml" line>',
+                                                peri: '<code>',
+                                                post: '</syntaxhighlight>'
+                                            }
+                                        }
+                                    },
+                                    'loopsnippets-accordion': {
+                                        labelMsg: 'loopwikieditor-loop-snippets-accordion',
+                                        action: {
+                                            type: 'encapsulate',
+                                            options: {
+                                                pre: '<loop_accordion>\n<loop_row>\n<loop_title>Title 1</loop_title>\n',
+                                                peri: 'Text',
+                                                post: '\n</loop_row>\n<loop_row>\n<loop_title>Title 2</loop_title>\nText 2\n</loop_accordion>\n'
+                                            }
+                                        }
+                                    },
                                     'loopsnippets-math': {
                                         labelMsg: 'loopwikieditor-loop-snippets-math',
                                         action: {

--- a/schema/loop_structure_items.sql
+++ b/schema/loop_structure_items.sql
@@ -13,12 +13,3 @@ CREATE TABLE IF NOT EXISTS /*_*/loop_structure_items (
 	PRIMARY KEY (lsi_id),
 	UNIQUE KEY structure_article (lsi_structure,lsi_article)
 )/*$wgDBTableOptions*/;
-
--- Migrate old structures items
-INSERT INTO /*$wgDBprefix*/loop_structure_items (lsi_article,lsi_previous_article,lsi_next_article,lsi_parent_article,lsi_toc_level,lsi_sequence,lsi_toc_number,lsi_toc_text) SELECT ArticleId, PreviousArticleId, NextArticleId, ParentArticleId, TocLevel, Sequence, TocNumber, TocText FROM /*$wgDBprefix*/loopstructure;
-
--- Set default structure
-INSERT INTO /*$wgDBprefix*/loop_structure_items (lsi_structure) VALUES (0);
-
--- Delete empty row
-DELETE FROM /*$wgDBprefix*/loop_structure_items WHERE lsi_article = 0 AND lsi_next_article = 0;

--- a/schema/loop_structure_items_modify.sql
+++ b/schema/loop_structure_items_modify.sql
@@ -1,0 +1,8 @@
+-- Migrate old structures items
+INSERT INTO /*$wgDBprefix*/loop_structure_items (lsi_article,lsi_previous_article,lsi_next_article,lsi_parent_article,lsi_toc_level,lsi_sequence,lsi_toc_number,lsi_toc_text) SELECT ArticleId, PreviousArticleId, NextArticleId, ParentArticleId, TocLevel, Sequence, TocNumber, TocText FROM /*$wgDBprefix*/loopstructure;
+
+-- Set default structure
+INSERT INTO /*$wgDBprefix*/loop_structure_items (lsi_structure) VALUES (0);
+
+-- Delete empty row
+DELETE FROM /*$wgDBprefix*/loop_structure_items WHERE lsi_article = 0 AND lsi_next_article = 0;

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2062,9 +2062,11 @@
 			</xsl:choose>
 		</xsl:variable>	
 	
+		<fo:block>
 		<fo:float>
-			<xsl:attribute name="float" value="$align"></xsl:attribute>				
-				<xsl:choose>
+			<xsl:attribute name="float" value="end" border="1px solid black"></xsl:attribute>		
+
+			<xsl:choose>
 				<xsl:when test="$align='start'">
 					<xsl:attribute name="axf:float-margin-x">5mm</xsl:attribute>
 				</xsl:when>			
@@ -2089,13 +2091,23 @@
 							<xsl:otherwise>
 								<xsl:attribute name="padding-left">0mm</xsl:attribute>
 							</xsl:otherwise>
-						</xsl:choose> -->							
+						</xsl:choose> 						 -->
 						<xsl:attribute name="src" ><xsl:value-of select="@imagepath"></xsl:value-of></xsl:attribute>
-						<xsl:attribute name="max-width">145mm</xsl:attribute>
+						<xsl:choose>
+							<xsl:when test="@imagewidth">
+								<xsl:attribute name="content-width"><xsl:value-of select="@imagewidth"></xsl:value-of></xsl:attribute>
+							</xsl:when>		
+							<xsl:otherwise>
+								<xsl:attribute name="max-width">145mm</xsl:attribute>
+							</xsl:otherwise>
+						</xsl:choose>
+						
 					</fo:external-graphic>
+					
 				</fo:block>
 			</xsl:if>
-		</fo:float>		
+		</fo:float>
+				</fo:block>	
 	</xsl:template>	
 	
 	<xsl:template match="extension" mode="loop_object">

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2233,10 +2233,14 @@
 			</xsl:when>
 			
 			<xsl:when test="@extension_name='syntaxhighlight'">
-				<fo:inline>
+				<fo:block margin-top="5pt">
 					<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
-					<!-- <xsl:copy-of select="php:function('LoopXsl::xsl_transform_syntaxhighlight', .)"></xsl:copy-of> -->
-				</fo:inline>
+				</fo:block>
+			</xsl:when>
+			<xsl:when test="@extension_name='source'">
+				<fo:block margin-top="5pt">
+					<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
+				</fo:block>
 			</xsl:when>
 			<xsl:when test="@extension_name='loop_spoiler'">
 				<xsl:call-template name="spoiler"></xsl:call-template>
@@ -2250,12 +2254,21 @@
 			<xsl:when test="@extension_name='loop_accordion'">
 				<xsl:call-template name="loop_accordion"></xsl:call-template>
 			</xsl:when>
+			<xsl:when test="@extension_name='nowiki'">
+				<xsl:call-template name="nowiki"></xsl:call-template>
+			</xsl:when>
 
 			<xsl:otherwise>
 			</xsl:otherwise>
 		</xsl:choose>	
 	</xsl:template>
 	
+	<xsl:template name="nowiki">
+			<fo:inline>
+				<xsl:value-of select="."/>
+			</fo:inline>
+	</xsl:template>
+
 	<xsl:template name="glossary_exists">
 		<xsl:choose>
 			<xsl:when test="//*/glossary/article">
@@ -2523,12 +2536,15 @@
 
 	
 	<xsl:template match="xhtml:code">
-	
-		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" background-color="#f8f9fa" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt">
-			<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_code', .)" mode="syntaxhighlight"></xsl:apply-templates>
-			<!-- <xsl:apply-templates></xsl:apply-templates> -->
+		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt" margin-top="5pt">
+			<xsl:value-of select="."></xsl:value-of>
 		</fo:block>
+	</xsl:template>
 
+	<xsl:template match="xhtml:pre">
+		<fo:block linefeed-treatment="preserve" white-space-collapse="false" white-space-treatment="preserve" font-family="SourceCodePro" font-size="8.5pt" line-height="12pt" margin-top="5pt">
+			<xsl:value-of select="."></xsl:value-of>
+		</fo:block>
 	</xsl:template>
 	
 	<xsl:template match="xhtml:cite">
@@ -2584,7 +2600,7 @@
 	<xsl:template match="span" mode="syntaxhighlight">
 			<fo:wrapper width="50mm" wrap-option="wrap">
 		<xsl:choose>
-			<xsl:when test="@class='lineno'">
+			<xsl:when test="@class='line'">
 				<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
 			</xsl:when>
 			

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -694,7 +694,7 @@
 											<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
 										</xsl:otherwise>
 									</xsl:choose> 
-									<xsl:apply-templates mode="loop_object"/> 
+									<xsl:apply-templates/><!-- mode="loop_object"-->
 								</fo:block>
 							</fo:table-cell>	
 						</fo:table-row>
@@ -1148,7 +1148,7 @@
 							<fo:inline>	
 								<xsl:choose>
 									<xsl:when test="descendant::extension[@extension_name='loop_figure_title']">
-										<xsl:apply-templates select="descendant::extension[@extension_name='loop_figure_title']" mode="infigure"></xsl:apply-templates>
+										<xsl:apply-templates select="descendant::extension[@extension_name='loop_figure_title']" mode="loop_object"></xsl:apply-templates>
 									</xsl:when>
 									<xsl:when test="descendant::extension[@extension_name='loop_title']">
 										<xsl:apply-templates select="descendant::extension[@extension_name='loop_title']"></xsl:apply-templates>
@@ -2099,7 +2099,13 @@
 			<xsl:when test="@extension_name='loop_title'">
 				<xsl:apply-templates></xsl:apply-templates>
 			</xsl:when>
+			<xsl:when test="@extension_name='loop_figure_title'">
+				<xsl:apply-templates></xsl:apply-templates>
+			</xsl:when>
 			<xsl:when test="@extension_name='loop_description'">
+				<xsl:apply-templates></xsl:apply-templates>
+			</xsl:when>
+			<xsl:when test="@extension_name='loop_figure_description'">
 				<xsl:apply-templates></xsl:apply-templates>
 			</xsl:when>
 			<xsl:when test="@extension_name='loop_copyright'">
@@ -2117,13 +2123,14 @@
 	<xsl:template match="extension" mode="loop_accordion">
 		<xsl:choose>
 			<xsl:when test="@extension_name='loop_title'">
-				<fo:block font-weight="bold">
+				<fo:block>
 					<xsl:apply-templates></xsl:apply-templates>
 				</fo:block>
 			</xsl:when>
 			<xsl:when test="@extension_name='loop_row'">
-				<fo:block margin-bottom="3mm">
-					<xsl:apply-templates mode="loop_accordion"></xsl:apply-templates>
+				<fo:block margin-bottom="4mm">
+					<xsl:apply-templates select="./descendant::extension[@extension_name='loop_title']" mode="loop_accordion"></xsl:apply-templates>
+					<xsl:apply-templates></xsl:apply-templates>
 				</fo:block>
 			</xsl:when>
 		</xsl:choose>	
@@ -2257,7 +2264,6 @@
 			<xsl:when test="@extension_name='nowiki'">
 				<xsl:call-template name="nowiki"></xsl:call-template>
 			</xsl:when>
-
 			<xsl:otherwise>
 			</xsl:otherwise>
 		</xsl:choose>	
@@ -2441,30 +2447,6 @@
 		</xsl:choose>
 
 	</xsl:template>
-	
-	<xsl:template match="extension" mode="infigure">
-		<xsl:choose>
-			<xsl:when test="@extension_name='loop_figure_title'">
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>
-			<xsl:when test="@extension_name='loop_figure_description'">
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>	
-			<xsl:when test="@extension_name='loop_title'">
-				<!-- <xsl:apply-templates  mode="infigure"></xsl:apply-templates> -->
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>	
-			<xsl:when test="@extension_name='loop_description'">
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>	
-			<xsl:when test="@extension_name='loop_copyright'">
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>		
-			<xsl:when test="@extension_name='loop_task'">
-				<xsl:apply-templates select="node()[not(self::br) and not(self::xhtml:br)]"></xsl:apply-templates>
-			</xsl:when>		
-		</xsl:choose>
-	</xsl:template>	
 
 	
 	<xsl:template name="loop_reference">
@@ -2600,7 +2582,7 @@
 	<xsl:template match="span" mode="syntaxhighlight">
 			<fo:wrapper width="50mm" wrap-option="wrap">
 		<xsl:choose>
-			<xsl:when test="@class='line'">
+			<xsl:when test="@class='lineno'">
 				<xsl:apply-templates mode="syntaxhighlight"></xsl:apply-templates>
 			</xsl:when>
 			

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1730,14 +1730,14 @@
 	<!-- Loop Spoiler -->
 	<xsl:template name="spoiler">
 		<fo:block keep-together.within-page="always">
-			<fo:block font-weight="bold">
-				<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1mm" padding-right="1mm" padding-top="1mm" padding-bottom="1mm" border-style="solid" border-width="0.3mm" border-color="{$accent_color}">
+			<fo:block font-weight="bold" width="145mm">
+				<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1.3mm" padding-right="1.3mm" padding-top="1.3mm" padding-bottom="1.5mm">
 
 					<xsl:attribute name="background-color"><xsl:value-of select="$accent_color"></xsl:value-of></xsl:attribute>
 					<xsl:attribute name="color">#ffffff</xsl:attribute>					
 					<xsl:choose>
 						<xsl:when test="./descendant::extension[@extension_name='loop_spoiler_text']">
-							<xsl:apply-templates select="./descendant::extension[@extension_name='loop_spoiler_text']" mode="loop_object"></xsl:apply-templates>
+							<xsl:apply-templates select="./descendant::extension[@extension_name='loop_spoiler_text']"></xsl:apply-templates>
 						</xsl:when>
 						<xsl:when test="@text">
 							<xsl:value-of select="@text"></xsl:value-of>
@@ -1755,8 +1755,12 @@
 						<xsl:attribute name="padding-top">2mm</xsl:attribute>
 						<xsl:attribute name="padding-left">3mm</xsl:attribute>
 						<xsl:attribute name="padding-right">3mm</xsl:attribute>
-						<xsl:attribute name="padding-end">3mm</xsl:attribute>	
+						<xsl:attribute name="padding-end">3mm</xsl:attribute>
+	
 						<fo:block>
+							<xsl:if test="ancestor::extension[@extension_name='loop_area']">
+								<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
+							</xsl:if>
 							<xsl:apply-templates></xsl:apply-templates>
 						</fo:block>
 					</fo:table-cell>
@@ -2240,12 +2244,12 @@
 			</xsl:when>
 			
 			<xsl:when test="@extension_name='syntaxhighlight'">
-				<fo:block margin-top="5pt">
+				<fo:block margin-top="5pt" margin-bottom="5pt">
 					<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
 				</fo:block>
 			</xsl:when>
 			<xsl:when test="@extension_name='source'">
-				<fo:block margin-top="5pt">
+				<fo:block margin-top="5pt" margin-bottom="5pt">
 					<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_syntaxhighlight', .)" mode="syntaxhighlight"></xsl:apply-templates>
 				</fo:block>
 			</xsl:when>


### PR DESCRIPTION
**PDF**
- nowiki Tag hinzugefügt
- source Tag hinzugefügt (gleiche funktion wie syntaxhighlight, für Abwärtskomp.)
- code tag hat, wie in Loop1, keinen bg mehr 
- pre Tag hinzugefügt (wie code)
- Syntaxhighlight benutzt jetzt die mediawiki Shell anstelle des Symfony-process, so wie die extension.
- Syntayhighlight übersetzt jetzt auch lexer, die pygmentize nicht kennt
- loop_accordion inhalte werden jetzt regulär gerendert
- title und description in objekten werden nicht mehr im inhalt des objects gerendert
- Wenn nach einem [[Link]]Ein wort kein Leerzeichen hatte, verschwand das Wort (hier: "Ein") in der PDF.

**Allg.**
- loop_description tags funktionieren jetzt auch online (pdf ging bereits)
- WikiEditor mit Syntaxhighlight und Akkordeon
- Updater wieder aufgeteilt

**Skin**
- Code hat jetzt keinen bg mehr
- margins zu code-relevanten tags hinzugefügt