### PR TITLE
Fixes zu PDF, -Timeout, u.v.m.

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -335,7 +335,6 @@
 	"loopreference-error-unknown-titleoption" : "Die Referenz besitzt für den Parameter Titelanzeige (title) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Referenzen: XXX",
 	"loopreference-error-unknown-refid" : "Die Referenz bezieht sich auf eine unbekannte ID: '''$1'''.\nDokumentation zu Referenzen: XXX",
 	"loopreference-error-no-refid" : "Die Referenz besitzt keinen ID-Parameter (id).\nDokumentation zu Referenzen: XXX",
-	"loopspoiler-error-unknown-spoilertype" : "Der Spoiler <nowiki><loop_spoiler></nowiki> besitzt für den Parameter Bereichstyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Spoiler: XXX",
 
 	"loopexternalcontent-prezi-on": "auf", 
 	"namespace-special": "Spezial",
@@ -396,6 +395,7 @@
 	
 	"loop-error-missingrequired": "In dem Tag $1 fehlt der notwendige Parameter $2. Das Element kann nicht dargestellt werden.",
 	"loop-error-missingfile": "Die in dem Tag $1 angegebene Datei $2 ist nicht vorhanden. Bitte laden Sie sie hoch. {{PLURAL:$3|Das Element wird ohne die Datei dargestellt.|Das Element kann nicht dargestellt werden.}}",
+	"loop-error-unknown-param" : "Im Tag $1 enthält der Parameter $2 den unbekannten Wert '''$3'''.<br/>\nErlaubte Werte sind '''$4'''. Das Element wird nun standardmäßig mit dem Wert $5 dargestellt.",
 	"loopterminology": "Abkürzungsverzeichnis",
 	"loopterminologyedit": "Abkürzungsverzeichnis bearbeiten",
 	"loopterminology-warning-deleted": "Alle Einträge wurden aus dem Abkürzungsverzeichnis gelöscht.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -204,8 +204,6 @@
 	"looparea-icon-text-task" : "Aufgabe",
 	"looparea-icon-text-timerequirement" : "Zeitumfang",
 	"looparea-icon-text-websource" : "Websource",
-	"looparea-error-unknown-type-attribute" : "Dieser Seitenbereich besitzt für den Parameter Typ (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
-	"looparea-error-unknown-render-attribute" : "Dieser Seitenbereich besitzt für den Parameter Render (render) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 
 	"loopspoiler-default-title": "Lösung",
 	"loopprint-printingarea": "Druckbereich",
@@ -326,13 +324,7 @@
 	"looplegacy-biblio": "Der '''biblio'''-Tag wird seit LOOP2 nicht mehr unterstützt. Bitte benutzen Sie den neuen Tag '''<loop_literature>'''.",
 	"looplegacy-references": "Der '''references'''-Tag wird seit LOOP2 nicht mehr benötigt. Fußnoten werden jetzt automatisch am Seitenende dargestellt, wenn ein <ref>-Tag auf einer Seite benutzt wird.",
 
-	"loopobject-error-unknown-renderoption" : "Die Auszeichnung besitzt für den Parameter Renderoption (render) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
-	"loopobject-error-unknown-alignmentoption" : "Die Auszeichnung besitzt für den Parameter Ausrichtung (align) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
-	"loopobject-error-unknown-indexoption" : "Die Auszeichnung besitzt für den Parameter Indexierung (index) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
-	"loopobject-error-unknown-showcopyrightoption" : "Die Auszeichnung besitzt für den Parameter Copyright anzeigen (show_copyright) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Auszeichnungen: XXX",
 	"loopobject-error-dublicate-id" : "Die Objektauszeichnung besitzt keine einzigartige ID ($1). Auf der Seite '$2' ist ein weiteres Objekt mit der ID vorhanden. Bitte ändern Sie die ID und speichern Sie die Seiten neu ab, um eine korrekte Zählung sicherzustellen.",
-	"loopmedia-error-unknown-mediatype" : "Das Medienelement besitzt für den Parameter Medientyp (type) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Medienelementen: XXX",
-	"loopreference-error-unknown-titleoption" : "Die Referenz besitzt für den Parameter Titelanzeige (title) den unbekannten Wert '''$1'''.<br/>\nErlaubte Werte sind '''$2'''.\nDokumentation zu Referenzen: XXX",
 	"loopreference-error-unknown-refid" : "Die Referenz bezieht sich auf eine unbekannte ID: '''$1'''.\nDokumentation zu Referenzen: XXX",
 	"loopreference-error-no-refid" : "Die Referenz besitzt keinen ID-Parameter (id).\nDokumentation zu Referenzen: XXX",
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -204,8 +204,6 @@
 	"looparea-icon-text-task" : "Task",
 	"looparea-icon-text-timerequirement" : "Timerequirement",
 	"looparea-icon-text-websource" : "Websource",
-	"looparea-error-unknown-type-attribute" : "This object's type option (type) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
-	"looparea-error-unknown-render-attribute" : "This object's rendering option (render) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 
 	"loopspoiler-default-title": "Solution",
 	"loopprint-printversion": "Printing area",
@@ -326,13 +324,7 @@
 	"looplegacy-biblio": "The tag '''biblio''' is not supported since LOOP2. Please use the new tag '''<loop_literature>'''.",
 	"looplegacy-references": "The tag '''references''' is obsolete since LOOP2. Footnotes are automatically displayed at the end of the page as soon as there is a <ref> tag in use.",
 
-	"loopobject-error-unknown-renderoption" : "The object's render option (render) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
-	"loopobject-error-unknown-alignmentoption" : "The object's alignment option (align) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
-	"loopobject-error-unknown-indexingoption" : "The object's indexing option (index) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
-	"loopobject-error-unknown-showcopyrightoption" : "The object's show copyright option (show_copyright) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",	
 	"loopobject-error-dublicate-id" : "The object's ID is not unique ($1). On page '$2' is another object with that same ID. Please change the ID and save the pages again so the numbering will be correct.",
-	"loopmedia-error-unknown-mediatype" : "The media's type option (type) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
-	"loopreference-error-unknown-titleoption" : "The reference's show title option (title) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopreference-error-unknown-refid" : "The reference's given ID is unknown: '''$1'''.",
 	"loopreference-error-no-refid" : "The reference is missing a ID parameter (id).",
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -335,7 +335,6 @@
 	"loopreference-error-unknown-titleoption" : "The reference's show title option (title) contains an unknown value: '''$1'''.<br/>\nValid values are: '''$2'''.",
 	"loopreference-error-unknown-refid" : "The reference's given ID is unknown: '''$1'''.",
 	"loopreference-error-no-refid" : "The reference is missing a ID parameter (id).",
-	"loopspoiler-error-unknown-spoilertype" : "unknown spoiler type '''$1'''\nSupported types are $2",
 
 	"loopexternalcontent-prezi-on": "on", 
 	"namespace-special": "Special",
@@ -396,6 +395,7 @@
 	
 	"loop-error-missingrequired": "The tag $1 is missing the required parameter $2. The element can not be displayed.",
 	"loop-error-missingfile": "The given file $2 in this $1 tag could not be found. Please upload it first. {{PLURAL:$3|The element is displayed without that file.|The element can not be displayed.}}",
+	"loop-error-unknown-param" : "The tag $1 contains a parameter $2 with an unknown value '''$3'''.<br/>\nValid values are '''$4'''. The element is rendered by default with value $5.",
 	"loopterminology": "List of abbreviations",
 	"loopterminologyedit": "Edit list of abbreviations",
 	"loopterminology-warning-deleted": "All entries have been removed from the list of abbreviations.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -194,8 +194,6 @@
 	"looparea-icon-text-task" : "Tarea",
 	"looparea-icon-text-timerequirement" : "Tiempo requerido",
 	"looparea-icon-text-websource" : "Fuente de internet",
-	"looparea-error-unknown-type-attribute" : "Esta área del loop contiene un valor desconocido para el parámetro tipo (type): '''$1'''.<br/>\nValores válidos: '''$2'''.\nDocumentación sobre las adjudicaciones: XXX",
-	"looparea-error-unknown-render-attribute" : "Esta área del loop contiene un valor desconocido para el parámetro de renderizado (render): '''$1'''.<br/>\nValores válidos: '''$2'''.\nDocumentación sobre las adjudicaciones: XXX",
 
 	"loopspoiler-default-title": "Solución",
 	"loopprint-printversion": "Àrea de impresión",
@@ -316,13 +314,7 @@
 	"looplegacy-biblio": "La etiqueta '''biblio''' no tiene respaldo en LOOP2. Por favor, utilice la nueva etiqueta '''<loop_literature>'''.",
 	"looplegacy-references": "La etiqueta '''references''' es obsoleta en LOOP2. Las notas de pie se muestran automáticamente en la parte inferior de la página si se utiliza la etiqueta <ref>.",
 
-	"loopobject-error-unknown-renderoption" : "El atributo para el parámetro opción de renderizado (render) contiene un valor desconocido: '''$1'''.<br/>\nValores válidos: '''$2'''.",
-	"loopobject-error-unknown-alignmentoption" : "El atributo para el parámetro de alineación (align) contiene un valor desconocido: '''$1'''.<br/>\nValores válidos: '''$2'''.",
-	"loopobject-error-unknown-indexingoption" : "El atributo para el parámetro de idexación (index) contiene un valor desconocido: '''$1'''.<br/>\nValores válidos: '''$2'''.",	
-	"loopobject-error-unknown-showcopyrightoption" : "El atributo para el parámetro mostrar derechos de autor (show_copyright) contiene un valor desconocido: '''$1'''.<br/>\nValores válidos: '''$2'''.",	
 	"loopobject-error-dublicate-id" : "El ID del objeto no es único ($1). En la página '$2' existe otro objeto con el mismo ID. Por favor, cambie el ID del objeto y guarde las páginas nuevamente para que la numeración sea correcta.",
-	"loopmedia-error-unknown-mediatype" : "El elemento multimedia contiene un valor desconocido '''$1''' para el parámetro tipo de multimedia (type).<br/>\nValores válidos: '''$2'''.",
-	"loopreference-error-unknown-titleoption" : "La referencia bibliográfica contiene un valor desconocido '''$1''' para el parámetro mostrar título (title).<br/>\nValores válidos: '''$2'''.",
 	"loopreference-error-unknown-refid" : "El ID ingresado para la referencia: '''$1''', es desconocido.",
 	"loopreference-error-no-refid" : "La referencia bibliográfica no contiene el parámetro ID (id).",
 

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -325,7 +325,6 @@
 	"loopreference-error-unknown-titleoption" : "La referencia bibliográfica contiene un valor desconocido '''$1''' para el parámetro mostrar título (title).<br/>\nValores válidos: '''$2'''.",
 	"loopreference-error-unknown-refid" : "El ID ingresado para la referencia: '''$1''', es desconocido.",
 	"loopreference-error-no-refid" : "La referencia bibliográfica no contiene el parámetro ID (id).",
-	"loopspoiler-error-unknown-spoilertype" : "El Spoiler <nowiki><loop_spoiler></nowiki> contiene el valor desconocido '''$1''' para el parámetro tipo de área (type).<br/>\nValores válidos '''$2'''.\nDocumentación sobre spoiler: XXX",
 
 	"loopexternalcontent-prezi-on": "encendido", 
 	"namespace-special": "Especial",
@@ -397,6 +396,7 @@
 	"loopbugreport": "Reportar error",
     "loopbugreport-specialpage-title": "Reportar error",
     "loopbugreport-message-label": "Descripción de errores",
+	"loop-error-unknown-param" : "The tag $1 contains a parameter $2 with an unknown value '''$3'''.<br/>\nValid values are '''$4'''. The element is rendered by default with value $5.",
     "loopbugreport-page-label": "Página",
     "loopbugreport-send": "Enviar",
     "loopbugreport-email-subject": "Reporte de error $1 $2 del LOOP",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -396,6 +396,7 @@
 	
 	"loop-error-missingrequired": "General Error message for missing required parameters. $1 -> the tag that has a missing parameter; $2 -> The parameter that is missing. The element will not be displayed when this message is set.",
 	"loop-error-missingfile": "Error message for files that are not uploaded to the system. $1 -> the tag that has a missing file; $2 -> The given file name that could not be found; $3{{Plural|The element is displayed anyway.|The element can't be displayed without the file.}} ",
+	"loop-error-unknown-param" : "General Error message for unknown parameters entered in a tag. $1 -> the tag that has an unknown parameter; $2 -> The unknown parameter name; $3 -> The unknown value of that parameter; $4 -> Allowed values; $5 -> the given default for that tag;",
 	"loopterminology": "Special Page title of terminology/abbreviations page",
 	"loopterminologyedit": "Special Page title of terminology/abbreviations edit page",
 	"loopterminology-warning-deleted": "Feedback message for deleting all abbreviations",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -204,8 +204,6 @@
 	"looparea-icon-text-task" : "icon text of the looparea type task",
 	"looparea-icon-text-timerequirement" : "icon text of the looparea type timerequirement",
 	"looparea-icon-text-websource" : "icon text of the looparea type websource",
-	"looparea-error-unknown-type-attribute" : "Error Message rendered when render option is unknown\n\nParameters:\n* $1 - render option\n* $2 supported render options",
-	"looparea-error-unknown-render-attribute" : "Error Message rendered when render option is unknown\n\nParameters:\n* $1 - render option\n* $2 supported render options",
 
 	"loopspoiler-default-title": "default label for spoiler button",
 	"loopprint-printversion": "default label for print version button",
@@ -326,16 +324,9 @@
 	"looplegacy-biblio": "Special error message for biblio tag which has been deprecated in LOOP2 and replaced by loop_literature tag.",
 	"looplegacy-references": "Special error message for references tag is been obsolte since LOOP2.",
 
-	"loopobject-error-unknown-renderoption" : "Error Message rendered when render option is unknown\n\nParameters:\n* $1 - render option\n* $2 supported render options",
-	"loopobject-error-unknown-alignmentoption" : "Error Message rendered when align option is unknown\n\nParameters:\n* $1 - align option\n* $2 supported align options",
-	"loopobject-error-unknown-indexingoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - indexing option\n* $2 supported index options",
-	"loopobject-error-unknown-showcopyrightoption" : "Error Message rendered when index option is unknown\n\nParameters:\n* $1 - show_copyright option\n* $2 supported show_copyright options",
 	"loopobject-error-dublicate-id" : "Error Message rendered when Object has a dublicate ID: $1 -> given ID; $2 -> Page where the original ID is used",
-	"loopmedia-error-unknown-mediatype" : "Error Message rendered when type option is unknown\n\nParameters:\n* $1 - type option\n* $2 supported type options",
-	"loopreference-error-unknown-titleoption" : "Error Message rendered when title option is unknown\n\nParameters:\n* $1 - title option\n* $2 supported title options",
 	"loopreference-error-unknown-refid" : "Error Message rendered when id option is unknown.\n\nParameters:\n* $1 - given id",
 	"loopreference-error-no-refid" : "Error Message rendered when no id is given",
-	"loopspoiler-error-unknown-spoilertype" : "Error Message rendered when spoilertype is unknown\n\nParameters:\n* $1 - area type\n* $2 supported spoiler types",
 
 	"loopexternalcontent-prezi-on": "The 'on' as in 'View on Prezi.com'", 
 	"namespace-special": "Special name space message",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -335,7 +335,6 @@
 	"loopreference-error-unknown-titleoption" : "Värdet av parametern (title) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopreference-error-unknown-refid" : "Referensens angivit ID är okänd: '''$1'''.",
 	"loopreference-error-no-refid" : "Ingen ID (id) har angivits i referensen.",
-	"loopspoiler-error-unknown-spoilertype" : "Okänd typ av spoiler: '''$1'''\nTillåtna värden är: '''$2'''.",
 
 	"loopexternalcontent-prezi-on": "på", 
 	"namespace-special": "Special",
@@ -396,6 +395,7 @@
 	
 	"loop-error-missingrequired": "Taggen $1 saknas parametern $2. Elementet visas inte.",
 	"loop-error-missingfile": "Filen $2 som har angivits i taggen $1 kunde inte hittas. Vänligen ladda upp den. {{PLURAL:$3|Elementet visas uten filen.|Elementet visas inte.}}",
+	"loop-error-unknown-param" : "Parametern $2 av taggen $1 är ogiltig: '''$3'''.<br/>\nTillåtna värden är '''$4'''. Elementet visas med värdet $5.",
 	"loopterminology": "Förkortningar",
 	"loopterminologyedit": "Regidera förkortningar",
 	"loopterminology-warning-deleted": "Alla förkortningar har tagits bort.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -204,8 +204,6 @@
 	"looparea-icon-text-task" : "Uppgift",
 	"looparea-icon-text-timerequirement" : "Tidslinje",
 	"looparea-icon-text-websource" : "Websource",
-	"looparea-error-unknown-type-attribute" : "Värdet av parametern (type) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"looparea-error-unknown-render-attribute" : "Värdet av parametern (render) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 
 	"loopspoiler-default-title": "Lösning",
 	"loopprint-printversion": "Utskriftsavsnitt",
@@ -326,13 +324,7 @@
 	"looplegacy-biblio": "Taggen '''biblio''' har tagits bort i LOOP2. Använd <loop_literature><literature>''Key''</literature></loop_literature> istället.",
 	"looplegacy-references": "Taggen '''references''' är inte länge nödvändig sedan LOOP2. Fotnoter visas automatiskt.",
 
-	"loopobject-error-unknown-renderoption" : "Värdet av parametern (render) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"loopobject-error-unknown-alignmentoption" : "Värdet av parametern (align) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"loopobject-error-unknown-indexingoption" : "Värdet av parametern (index) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"loopobject-error-unknown-showcopyrightoption" : "Värdet av parametern (show_copyright) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopobject-error-dublicate-id" : "Objektet besitter ingen unik ID ($1). På sidan '$2' finns det ett annat objekt med den här ID. Vänligen byt ID:n och spara sidor igen, så objektet kan numereras korrekt.",
-	"loopmedia-error-unknown-mediatype" : "Värdet av parametern (type) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
-	"loopreference-error-unknown-titleoption" : "Värdet av parametern (title) är ökänd: '''$1'''.<br/>\nTillåtna värden är: '''$2'''.",
 	"loopreference-error-unknown-refid" : "Referensens angivit ID är okänd: '''$1'''.",
 	"loopreference-error-no-refid" : "Ingen ID (id) har angivits i referensen.",
 

--- a/includes/LoopArea.php
+++ b/includes/LoopArea.php
@@ -69,7 +69,7 @@ class LoopArea {
 				} else {	
 					$argtype = 'area';
 					$iconimg = $argtype;
-					throw new LoopException( wfMessage( 'looparea-error-unknown-type-attribute', $args['type'], implode( ', ', self::$typeOptions ) )->text() );
+					throw new LoopException( wfMessage( "loop-error-unknown-param", "<loop_area>", "type", $args['type'], implode( ', ', self::$typeOptions ), 'area' )->text() );
 				}
 			} else {
 				// ... set default type
@@ -93,7 +93,7 @@ class LoopArea {
 				} elseif ( $args['render'] === 'marked') {
 					$cssrender = 'rendermarked';
 				} else {
-					throw new LoopException( wfMessage( 'looparea-error-unknown-render-attribute', $args['render'], implode( ', ', self::$renderOptions ) )->text() );
+					throw new LoopException( wfMessage( "loop-error-unknown-param", "<loop_area>", "render", $args['render'], implode( ', ', self::$renderOptions ), "marked" )->text() );
 				}
 			}
 			

--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -171,6 +171,8 @@ class LoopExportXml extends LoopExport {
 		header("Last-Modified: " . date("D, d M Y H:i:s T", strtotime($this->structure->lastChanged())));
 		header("Content-Type: application/xml; charset=utf-8");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 
@@ -289,6 +291,7 @@ class LoopExportPageMp3 extends LoopExport {
 
 	public function generateExportContent() {
 		$query = $this->request->getQueryValues();
+		set_time_limit(30);
 		if ( isset( $query['articleId'] ) ) {
 			if ( isset( $query['debug'] ) ) {
 				$this->exportContent = LoopMp3::getMp3FromRequest($this->structure, $query['articleId'], $query['debug'] );

--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -509,7 +509,7 @@ class SpecialLoopExport extends SpecialPage {
 			if ($export->getExportContent() != null ) {
 				
 				if ( isset($logEntry) ) {
-					$logEntry->setTarget( Title::newFromId(1) );
+					$logEntry->setTarget( Title::newFromId($structure->mainPage) );
 					$logEntry->setPerformer( User::newFromId(0) ); 
 					$logEntry->setParameters( [ '4::paramname' => $logMsg ] );
 					$logid = $logEntry->insert();

--- a/includes/LoopMedia.php
+++ b/includes/LoopMedia.php
@@ -114,7 +114,7 @@ class LoopMedia extends LoopObject{
 		
 		if ( ! in_array ( $this->getMediaType(), self::$mMediaTypes ) ) {
 			$this->setMediaType('media');
-			$e = new LoopException( wfMessage( 'loopmedia-error-unknown-mediatype', $mediatype, implode( ', ',self::$mMediaTypes ) )->text() );
+			$e = new LoopException( wfMessage ( "loop-error-unknown-param", "<loop_media>", "type", $this->GetArg('type'), implode ( ', ', self::$mMediaTypes ), 'media' )->text() );
 			$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 			$this->error = $e;
 		}		

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -622,6 +622,7 @@ class LoopObject {
 	 */
 	public function preParse() {
 		
+		$this->error = "";
 		if ($id = $this->GetArg('id')) {
 			$this->setId(htmlspecialchars($id));
 		}
@@ -637,9 +638,11 @@ class LoopObject {
 			$this->setRenderOption($this->getDefaultRenderOption());
 		}
 		if ( ! in_array ( $this->getRenderOption(), self::$mRenderOptions ) ) {
-			$e = new LoopException( wfMessage( 'loopobject-error-unknown-renderoption', $renderoption, implode( ', ', self::$mRenderOptions ) )->text() );
+			$e = new LoopException( wfMessage( "loop-error-unknown-param", "<".$this->getTag().">", "render", $this->GetArg('render'), implode( ', ', self::$mRenderOptions ), $this->getDefaultRenderOption() )->text() );
+			$this->setRenderOption($this->getDefaultRenderOption());
+				
 			$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
-			$this->error = $e;
+			$this->error .= $e;
 		}
 		
 		try {
@@ -652,12 +655,12 @@ class LoopObject {
 			if ( ! in_array ( $this->getAlignment(), self::$mAlignmentOptions ) ) {
 				global $wgParser, $wgFrame;
 				$this->setAlignment('none');
-				throw new LoopException( wfMessage( 'loopobject-error-unknown-alignmentoption',$alignment, implode( ', ', self::$mAlignmentOptions ) )->text() );
-				
+				throw new LoopException( wfMessage( "loop-error-unknown-param", "<".$this->getTag().">", "align", $this->GetArg('align'), implode( ', ', self::$mAlignmentOptions ), 'none' )->text() );
+			
 			}	
 		} catch ( LoopException $e ) {
 			$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
-			$this->error = $e;
+			$this->error .= $e;
 		}
 		
 		if ($title = $this->GetArg('title')) {
@@ -681,7 +684,7 @@ class LoopObject {
 				$this->setShowCopyright(false);
 				break;
 			default:
-				$e = new LoopException( wfMessage( 'loopobject-error-unknown-showcopyrightoption', $showcopyright, implode( ', ', self::$mShowCopyrightOptions ) )->text() );
+				$e = new LoopException( wfMessage( "loop-error-unknown-param", "<".$this->getTag().">", "show_copyright", $this->GetArg('show_copyright'), implode( ', ', self::$mShowCopyrightOptions  ), "false" )->text() );
 				$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 				$this->error = $e;
 		}
@@ -701,7 +704,7 @@ class LoopObject {
 				break;
 			default:
 				$this->setIndexing(true);
-				$e = new LoopException( wfMessage( 'loopobject-error-unknown-indexoption', $indexing, implode( ', ', self::$mIndexingOptions ) )->text() );
+				$e = new LoopException( wfMessage( "loop-error-unknown-param", "<".$this->getTag().">", "index", $this->GetArg('index'), implode( ', ', self::$mIndexingOptions ), "true" )->text() );
 				$this->getParser()->addTrackingCategory( 'loop-tracking-category-error' );
 				$this->error = $e;
 				break;

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -21,11 +21,12 @@ class LoopPdf {
 	*/
 	public static function structure2pdf(LoopStructure $structure, $modifiers = null) {
 		global $IP;
-
+#echo "hello!";exit;
 		$wiki_xml = LoopXml::structure2xml($structure);
 		$errors = '';
-		
+		#echo "xml ok!<br>";
 		$xmlfo = self::transformToXmlfo( $wiki_xml );
+		#echo "xmlfo ok!";exit;
 		$pdf = self::makePdfRequest( $xmlfo["xmlfo"] );
 		
 		if ( !empty($errors) ) {

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -22,14 +22,16 @@ class LoopPdf {
 	public static function structure2pdf(LoopStructure $structure, $modifiers = null) {
 		global $IP;
 		
+		set_time_limit(300);
+
 		$wiki_xml = LoopXml::structure2xml($structure);
 		$errors = '';
-		
+
 		$xmlfo = self::transformToXmlfo( $wiki_xml );
 		$pdf = self::makePdfRequest( $xmlfo["xmlfo"] );
 		
-		if ( !empty($errors) ) {
-			var_dump($errors);
+		if ( !empty($xmlfo["errors"]) ) {
+			var_dump($xmlfo["errors"]);
 		}
 		if ( strpos( $pdf, "%PDF") !== 0 ) {
 			#es werden keine leeren/fehlerhaften PDFs mehr heruntergeladen, solange das hier aktiv ist.

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -21,12 +21,11 @@ class LoopPdf {
 	*/
 	public static function structure2pdf(LoopStructure $structure, $modifiers = null) {
 		global $IP;
-#echo "hello!";exit;
+		
 		$wiki_xml = LoopXml::structure2xml($structure);
 		$errors = '';
-		#echo "xml ok!<br>";
+		
 		$xmlfo = self::transformToXmlfo( $wiki_xml );
-		#echo "xmlfo ok!";exit;
 		$pdf = self::makePdfRequest( $xmlfo["xmlfo"] );
 		
 		if ( !empty($errors) ) {

--- a/includes/LoopReference.php
+++ b/includes/LoopReference.php
@@ -45,7 +45,6 @@ class LoopReference {
 				throw new LoopException( wfMessage( 'loopreference-error-no-refid' )->text());
 			}
 
-
 			if ( ! $objectData ) {
 				throw new LoopException( wfMessage( 'loopreference-error-unknown-refid', $refId )->text());
 			}
@@ -56,7 +55,7 @@ class LoopReference {
 				$showTitle = false;
 			} else {
 				$showTitle = false;
-				throw new LoopException( wfMessage( 'loopreference-error-unknown-titleoption', $args["title"] , "true, false" )->text() );
+				throw new LoopException( wfMessage ( "loop-error-unknown-param", "<loop_reference>", "title", $args["title"], "true, false", 'false' )->text() );
 			}
 		} catch ( LoopException $e ) {
 			$parser->addTrackingCategory( 'loop-tracking-category-error' );

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -17,6 +17,9 @@ class LoopXml {
 	 */
 	public static function structure2xml(LoopStructure $loopStructure, Array $modifiers = null) {
 		global $wgCanonicalServer, $wgLanguageCode;
+
+		set_time_limit(3600);
+		ini_set('memory_limit', '1024M');
 		
 		$loopStructureItems = $loopStructure->getStructureItems();		
 		
@@ -95,7 +98,7 @@ class LoopXml {
 	 * 		"mp3" => true; modifies XML Output for MP3 export, adds additional breaks for loop_objects
 	 */
 	public static function structureItem2xml(LoopStructureItem $structureItem, Array $modifiers = null) {
-		
+
 		$title = Title::newFromId( $structureItem->getArticle () );
 		$fwp = new FlaggableWikiPage ( $title );
 		$stableRev = $fwp->getStable();
@@ -232,6 +235,7 @@ class LoopXml {
 	
 	
 	private static function structureItemToc(LoopStructureItem $structureItem) {
+		
 		$toc_xml = "<chapter>";
 	
 		$childs = $structureItem->getDirectChildItems();
@@ -432,7 +436,7 @@ class LoopXml {
 	}	
 
 	public static function glossary2xml( ) {
-
+		
 		$articles = LoopGlossary::getGlossaryPages( "idArray" );
 		$return = '';
 
@@ -447,7 +451,7 @@ class LoopXml {
 	}
 
 	public static function terminology2xml( ) {
-
+		
 		$terminology = LoopTerminology::getTerminologyPageContentText();
 		$items = LoopTerminology::getSortedTerminology( $terminology );
 
@@ -680,7 +684,12 @@ class wiki2xml
 						( $c5 == '/' && $c7 == '/' ) &&
 						$this->once ( $b , $x , "external_freelink" ) ) continue ;
 			} else {
-				if ( $c == "{" && $this->once ( $b , $x , "template" ) ) continue ;
+				# LOOP CHANGE for endless loop [{{filepath:Prokrastination_Fragebogen_Rist.pdf}} Fragebogen]
+				if ( $closeit != "}}" ) {
+					if ( $c == "{" && $this->once ( $b , $x , "template" ) ) continue ;
+				} else {
+					return false;
+				}
 			}
 			$x .= htmlspecialchars ( $c ) ;
 			$b++ ;
@@ -896,6 +905,7 @@ class wiki2xml
 	}
 
 	function replace_template_variables ( &$text , &$variables ) {
+		
 		global $xmlg ;
 		if ( $xmlg["useapi"] ) return false ; # API already resolved templates
 		for ( $a = 0 ; $a+3 < strlen ( $text ) ; $a++ ) {
@@ -905,6 +915,7 @@ class wiki2xml
 	}
 
 	function p_template_replace_single_variable ( &$text , $a , &$variables ) {
+		
 		if ( mb_substr ( $text , $a , 3 ) != '{{{' ) return false ;
 		$b = $a + 3 ;
 

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -18,7 +18,7 @@ class LoopXml {
 	public static function structure2xml(LoopStructure $loopStructure, Array $modifiers = null) {
 		global $wgCanonicalServer, $wgLanguageCode;
 
-		set_time_limit(3600);
+		set_time_limit(300);
 		ini_set('memory_limit', '1024M');
 		
 		$loopStructureItems = $loopStructure->getStructureItems();		
@@ -45,6 +45,7 @@ class LoopXml {
 		
 		$articles = '<articles xmlns:xhtml="http://www.w3.org/1999/xhtml">';
 		foreach ( $loopStructureItems as $loopStructureItem ) {
+			#echo $loopStructureItem->article . "<br>";
 		    $articles .= self::structureItem2xml ( $loopStructureItem, $modifiers );
 		}
 		$articles .= "</articles>\n";
@@ -498,7 +499,6 @@ class LoopXml {
  * 
  */
 
-
 class wiki2xml
 {
 	var $cnt = 0 ; # For debugging purposes
@@ -575,7 +575,7 @@ class wiki2xml
 	 */
 	function once ( &$a , &$xml , $f , $atleastonce = true , $many = false )
 	{
-
+		#echo("<br>w2x_2");
 		$f = "p_{$f}" ;
 		$cnt = 0 ;
 		#		print $f . " : " . htmlentities ( mb_substr ( $this->w , $a , 20 ) ) . "<br/>" ; flush () ;
@@ -594,11 +594,21 @@ class wiki2xml
 
 	function onceormore ( &$a , &$xml , $f )
 	{
+		#echo("<br>w2x_3");
 		return $this->once ( $a , $xml , $f , true , true ) ;
 	}
 
 	function nextis ( &$a , $t , $movecounter = true )
 	{
+		#echo("<br>w2x_4");
+		#echo "[$a]" . "";
+		#echo  "[$t]" . "";
+		//#echo mb_substr ( $this->w , $a , strlen ( $t ) ) != $t . "<br>";
+		//##echo ",a:" . $a .",t:".$t .",mc:".mb_substr ( $this->w , $a , strlen ( $t ) ));
+		#exit;
+		if ( $t == "{{" ) {
+			return true;
+		}
 		if ( mb_substr ( $this->w , $a , strlen ( $t ) ) != $t ) return false ;
 		if ( $movecounter ) $a += strlen ( $t ) ;
 		return true ;
@@ -606,6 +616,7 @@ class wiki2xml
 
 	function nextchar ( &$a , &$x )
 	{
+		#echo("<br>w2x_5");
 		if ( $a >= $this->wl ) return false ;
 		$c = mb_substr ( $this->w , $a , 1 , 'UTF-8' );
 		$x .= htmlspecialchars ( $c ) ;
@@ -615,6 +626,7 @@ class wiki2xml
 
 	function ischaracter ( $c )
 	{
+		#echo("<br>w2x_6");
 		if ( $c >= 'A' && $c <= 'Z' ) return true ;
 		if ( $c >= 'a' && $c <= 'z' ) return true ;
 		return false ;
@@ -622,6 +634,7 @@ class wiki2xml
 
 	function skipblanks ( &$a , $blank = " " )
 	{
+		#echo("<br>w2x_7");
 		while ( $a < $this->wl )
 		{
 			$c = mb_substr ( $this->w , $a , 1 , 'UTF-8' );
@@ -635,11 +648,13 @@ class wiki2xml
 
 	function p_internal_link_target ( &$a , &$xml , $closeit = "]]" )
 	{
+		#echo("<br>w2x_8");
 		return $this->p_internal_link_text ( $a , $xml , true , $closeit ) ;
 	}
 
 	function p_internal_link_text2 ( &$a , &$xml , $closeit )
 	{
+		#echo("<br>w2x_9");
 		$bi = $this->bold_italics ;
 		$ret = $this->p_internal_link_text ( $a , $xml , false , $closeit , false ) ;
 		if ( $closeit == ']]' && '' != $this->bold_italics ) $ret = false ; # Dirty hack to ensure good XML; FIXME!!!
@@ -648,6 +663,7 @@ class wiki2xml
 
 	function p_internal_link_text ( &$a , &$xml , $istarget = false , $closeit = "]]" , $mark = true )
 	{
+		#echo("<br>w2x_10");
 		$b = $a ;
 		$x = "" ;
 		if ( $b >= $this->wl ) return false ;
@@ -721,6 +737,7 @@ class wiki2xml
 
 	function p_internal_link_trail ( &$a , &$xml )
 	{
+		#echo("<br>w2x_11");
 		$b = $a ;
 		$x = "" ;
 		while ( 1 )
@@ -747,6 +764,7 @@ class wiki2xml
 
 	function p_internal_link ( &$a , &$xml )
 	{
+		#echo("<br>w2x_12");
 		$x = "" ;
 		$b = $a ;
 		if ( !$this->nextis ( $b , "[[" ) ) return false ;
@@ -765,6 +783,7 @@ class wiki2xml
 
 	function p_magic_variable ( &$a , &$xml )
 	{
+		#echo("<br>w2x_13");
 		$x = "" ;
 		$b = $a ;
 		if ( !$this->nextis ( $b , "__" ) ) return false ;
@@ -780,6 +799,7 @@ class wiki2xml
 	# Template and template variable, utilizing parts of the internal link methods
 	function p_template ( &$a , &$xml )
 	{
+		#echo("<br>w2x_14");
 		global $content_provider , $xmlg ;
 		if ( $xmlg["useapi"] ) return false ; # API already resolved templates
 
@@ -882,6 +902,7 @@ class wiki2xml
 
 	function process_template_logic ( $title , $variables ) {
 
+		#echo("<br>w2x_15");
 		# TODO : Process title and variables for sub-template-replacements
 
 		if ( mb_substr ( $title , 0 , 4 ) == "#if:" ) {
@@ -906,6 +927,7 @@ class wiki2xml
 
 	function replace_template_variables ( &$text , &$variables ) {
 		
+		#echo("<br>w2x_16");
 		global $xmlg ;
 		if ( $xmlg["useapi"] ) return false ; # API already resolved templates
 		for ( $a = 0 ; $a+3 < strlen ( $text ) ; $a++ ) {
@@ -916,6 +938,7 @@ class wiki2xml
 
 	function p_template_replace_single_variable ( &$text , $a , &$variables ) {
 		
+		#echo("<br>w2x_17");
 		if ( mb_substr ( $text , $a , 3 ) != '{{{' ) return false ;
 		$b = $a + 3 ;
 
@@ -959,6 +982,7 @@ class wiki2xml
 
 	function p_template_variable ( &$a , &$xml )
 	{
+		#echo("<br>w2x_18");
 		$x = "" ;
 		$b = $a ;
 		if ( !$this->nextis ( $b , "{{{" ) ) return false ;
@@ -972,16 +996,19 @@ class wiki2xml
 	# Bold / italics
 	function p_bold ( &$a , &$xml , $recurse = "restofline" , $end = "" )
 	{
+		#echo("<br>w2x_19");
 		return $this->p_intwined ( $a , $xml , "bold" , "'''" , $recurse , $end ) ;
 	}
 
 	function p_italics ( &$a , &$xml , $recurse = "restofline" , $end = "" )
 	{
+		#echo("<br>w2x_20");
 		return $this->p_intwined ( $a , $xml , "italics" , "''" , $recurse , $end ) ;
 	}
 
 	function p_intwined ( &$a , &$xml , $tag , $markup , $recurse , $end )
 	{
+		#echo("<br>w2x_21");
 		$b = $a ;
 		if ( !$this->nextis ( $b , $markup ) ) return false ;
 		$id = mb_substr ( ucfirst ( $tag ) , 0 , 1 ) ;
@@ -1023,6 +1050,7 @@ class wiki2xml
 
 	function scanplaintext ( &$a , &$xml , $goodstop , $badstop )
 	{
+		#echo("<br>w2x_22");
 		$b = $a ;
 		$x = "" ;
 		while ( $b < $this->wl )
@@ -1045,6 +1073,7 @@ class wiki2xml
 	# External link
 	function p_external_freelink ( &$a , &$xml , $mark = true )
 	{
+		#echo("<br>w2x_23");
 		if ( $this->wl <= $a + 10 ) return false ; # Can't have an URL shorter than that
 
 		$c5 = mb_substr ( $this->w , $a+5 , 1 , 'UTF-8' );
@@ -1087,6 +1116,7 @@ class wiki2xml
 
 	function p_external_link ( &$a , &$xml , $mark = true )
 	{
+		#echo("<br>w2x_24");
 		$b = $a ;
 		if ( !$this->nextis ( $b , "[" ) ) return false ;
 		$url = "" ;
@@ -1106,6 +1136,7 @@ class wiki2xml
 	# Heading
 	function p_heading ( &$a , &$xml )
 	{
+		#echo("<br>w2x_25");
 		if ( $a >= $this->wl || (mb_substr ( $this->w , $a , 1 , 'UTF-8' )) != '=' ) return false ;
 		$b = $a ;
 		$level = 0 ;
@@ -1133,6 +1164,7 @@ class wiki2xml
 	# Often used function for parsing the rest of a text line
 	function p_restofline ( &$a , &$xml , $closeit = array() )
 	{
+		#echo("<br>w2x_26");
 		$b = $a ;
 		$x = "" ;
 		$override = false ;
@@ -1178,6 +1210,7 @@ class wiki2xml
 
 	function p_line ( &$a , &$xml , $force )
 	{
+		#echo("<br>w2x_27");
 		if ( $a >= $this->wl ) return false ; # Already at the end of the text
 		#$c = $this->w[$a] ;
 		$c = mb_substr ( $this->w , $a , 1 , 'UTF-8' );
@@ -1196,12 +1229,14 @@ class wiki2xml
 
 	function p_blankline ( &$a , &$xml )
 	{
+		#echo("<br>w2x_28");
 		if ( $this->nextis ( $a , "\n" ) ) return true ;
 		return false ;
 	}
 
 	function p_block_lines ( &$a , &$xml , $force = false )
 	{
+		#echo("<br>w2x_29");
 		$x = "" ;
 		$b = $a ;
 		if ( !$this->p_line ( $b , $x , $force ) ) return false ;
@@ -1218,6 +1253,7 @@ class wiki2xml
 	# Parses a line starting with ' '
 	function p_preline ( &$a , &$xml )
 	{
+		#echo("<br>w2x_30");
 		if ( $a >= $this->wl ) return false ; # Already at the end of the text
 		if ( (mb_substr ( $this->w , $a , 1 , 'UTF-8' ))!= ' ' ) return false ; # Not a preline
 
@@ -1234,6 +1270,7 @@ class wiki2xml
 	# Parses a block of lines each starting with ' '
 	function p_block_pre ( &$a , &$xml )
 	{
+		#echo("<br>w2x_31");
 		$x = "" ;
 		$b = $a ;
 		if ( !$this->once ( $b , $x , "preline" , true , true ) ) return false ;
@@ -1247,6 +1284,7 @@ class wiki2xml
 	# Returns a list tag depending on the wiki markup
 	function listtag ( $c , $open = true )
 	{
+		#echo("<br>w2x_32");
 		if ( !$open ) return "</list>" ;
 		$r = "" ;
 		if ( $c == '#' ) $r = "numbered" ;
@@ -1261,6 +1299,7 @@ class wiki2xml
 	# Opens/closes list tags
 	function fixlist ( $last , $cur )
 	{
+		#echo("<br>w2x_33");
 		$r = "" ;
 		$olast = $last ;
 		$ocur = $cur ;
@@ -1297,6 +1336,7 @@ class wiki2xml
 	# Parses a single list line
 	function p_list_line ( &$a , &$xml , &$last )
 	{
+		#echo("<br>w2x_34");
 		$cur = "" ;
 		do {
 			$lcur = $cur ;
@@ -1344,6 +1384,7 @@ class wiki2xml
 	# Checks for a list block ( those nasty things starting with '*', '#', or the like...
 	function p_block_list ( &$a , &$xml )
 	{
+		#echo("<br>w2x_35");
 		$last = "" ;
 		$found = false ;
 		while ( $this->p_list_line ( $a , $xml , $last ) ) $found = true ;
@@ -1356,6 +1397,7 @@ class wiki2xml
 	# Returns false otherwise.
 	function p_html ( &$a , &$xml )
 	{
+		#echo("<br>w2x_36");
 		if ( !$this->nextis ( $a , "<" , false ) ) return false ;
 
 		$b = $a ;
@@ -1482,6 +1524,7 @@ class wiki2xml
 
 	function strip_single_paragraph ( $s )
 	{
+		#echo("<br>w2x_37");
 		if ( mb_substr_count ( $s , "paragraph>" ) == 2 &&
 			 mb_substr ( $s , 0 , 11 ) == "<paragraph>" &&
 			 mb_substr ( $s , -12 ) == "</paragraph>" )
@@ -1493,6 +1536,7 @@ class wiki2xml
 	# Only to be called from p_html, as it returns only a partial extension tag!
 	function p_html_tag ( &$a , &$xml , &$tag , &$closing , &$selfclosing )
 	{
+		#echo("<br>w2x_38");
 		if ( (mb_substr ( $this->w , $a , 1 , 'UTF-8' )) != '<' ) return false ;
 		$b = $a + 1 ;
 		$this->skipblanks ( $b ) ;
@@ -1560,6 +1604,7 @@ class wiki2xml
 	# It is used for both HTML tags and wiki tables
 	function preparse_attributes ( $x )
 	{
+		#echo("<br>w2x_39");
 		# Creating a temporary new parser to run the attribute list in
 		$np = new wiki2xml ;
 		$np->inherit ( $this ) ;
@@ -1615,6 +1660,7 @@ class wiki2xml
 	# This function scans a single HTML tag attribute and returns it as <attr name='key'>value</attr>
 	function p_html_attr ( &$a , &$xml )
 	{
+		#echo("<br>w2x_40");
 		$b = $a ;
 		$this->skipblanks ( $b ) ;
 		if ( $b >= $this->wl ) return false ;
@@ -1684,6 +1730,7 @@ class wiki2xml
 	# Horizontal ruler (<hr> / ----)
 	function p_hr ( &$a , &$xml )
 	{
+		#echo("<br>w2x_41");
 		if ( !$this->nextis ( $a , "----" ) ) return false ;
 		$this->skipblanks ( $a , "-" ) ;
 		$this->skipblanks ( $a ) ;
@@ -1695,6 +1742,7 @@ class wiki2xml
 	# Scans the rest of the line as HTML attributes and returns the usual <attrs><attr> string
 	function scanattributes ( &$a )
 	{
+		#echo("<br>w2x_42");
 		$x = "" ;
 		while ( $a < $this->wl )
 		{
@@ -1719,6 +1767,7 @@ class wiki2xml
 	# Finds the first of the given items; does *not* alter $a
 	function scanahead ( $a , $matches )
 	{
+		#echo("<br>w2x_43");
 		while ( $a < $this->wl )
 		{
 			foreach ( $matches AS $x )
@@ -1737,6 +1786,7 @@ class wiki2xml
 	# The main table parsing function
 	function p_table ( &$a , &$xml )
 	{
+		#echo("<br>w2x_44");
 		if ( $a >= $this->wl ) return false ;
 		$c = (mb_substr ( $this->w , $a , 1 , 'UTF-8' )) ;
 		if ( $c == "{" && $this->nextis ( $a , "{|" , false ) )
@@ -1762,12 +1812,14 @@ class wiki2xml
 
 	function lasttable ()
 	{
+		#echo("<br>w2x_45");
 		return $this->tables[count($this->tables)-1] ;
 	}
 
 	# Returns the attributes for table cells
 	function tryfindparams ( &$a )
 	{
+		#echo("<br>w2x_46");
 		$n = strspn ( $this->w , $this->allowed , $a ) ; # PHP 4.3.0 and above
 		#		$n = strspn ( mb_substr ( $this->w , $a ) , $this->allowed ) ; # PHP < 4.3.0
 		if ( $n == 0 ) return "" ; # None found
@@ -1786,6 +1838,7 @@ class wiki2xml
 
 	function p_table_element ( &$a , &$xml , $newline = false )
 	{
+		#echo("<br>w2x_47");
 		#		print "p_table_element for " . htmlentities ( mb_substr ( $this->w , $a ) ) . "<br/><br/>" ; flush () ;
 		$b = $a ;
 		$this->skipblanks ( $b ) ; # Compatability for table cells starting with blanks; *evil MediaWiki parser!*
@@ -1848,6 +1901,7 @@ class wiki2xml
 	# then runs a new parser on it
 	function p_restofcell ( &$a , &$xml )
 	{
+		#echo("<br>w2x_48");
 		# Get mb_substring for cell
 		$b = $a ;
 		$sameline = true ;
@@ -1894,6 +1948,7 @@ class wiki2xml
 
 	function p_table_close ( &$a , &$xml )
 	{
+		#echo("<br>w2x_49");
 		if ( count ( $this->tables ) == 0 ) return false ;
 		$b = $a ;
 		if ( !$this->nextis ( $b , "|}" ) ) return false ;
@@ -1911,6 +1966,7 @@ class wiki2xml
 
 	function p_table_open ( &$a , &$xml )
 	{
+		#echo("<br>w2x_50");
 		$b = $a ;
 		if ( !$this->nextis ( $b , "{|" ) ) return false ;
 
@@ -1950,6 +2006,7 @@ class wiki2xml
 	# Parse the article
 	function p_article ( &$a , &$xml )
 	{
+		#echo("<br>w2x_51");
 		$x = "" ;
 		$b = $a ;
 		while ( $b < $this->wl )
@@ -1980,6 +2037,9 @@ class wiki2xml
 	# The only function to be called directly from outside the class
 	function parse ( &$wiki )
 	{
+		
+		set_time_limit(300);
+		#echo("<br>w2x_52");
 		global $IP;
 
 		$this->w = rtrim ( $wiki ) ;

--- a/includes/LoopXsl.php
+++ b/includes/LoopXsl.php
@@ -490,4 +490,46 @@ class LoopXsl {
 
 		return $wgLoopLegacyPageNumbering;
 	}
+	
+	public static function xsl_transform_table_attributes( $input, $area, $spoiler, $object ) {
+		
+		$table = $input[0];
+		if ( $area == "true" ) {
+			$table->setAttribute( "looparea", "true");
+		} 
+		if ( $spoiler == "true" ) {
+			$table->setAttribute( "loopspoiler", "true");
+		} 
+		if ( $object == "true" ) {
+			$table->setAttribute( "loopobject", "true");
+		} 
+
+		foreach ( $table->childNodes as $rowNode ) {
+			foreach ( $rowNode->childNodes as $node ) {
+				$strpos = strpos( $node->nodeValue, "|" );
+				if ( $strpos !== false ) {
+					
+				foreach ( $node->childNodes as $childNode ) {
+							if ( $childNode->nodeName == "#text") {
+								$content = explode( "|", $childNode->nodeValue );
+								$attr = array();
+								preg_match('/style="(.*)"/Ui', $content[0], $attr["style"]);
+								preg_match('/colspan="(.*)"/Ui', $content[0], $attr["colspan"]);
+								preg_match('/rowspan="(.*)"/Ui', $content[0], $attr["rowspan"]);
+								foreach ( $attr as $k => $v  ) {
+									if ( !empty( $v ) ) {
+										$node->setAttribute( $k, $v[1]);
+									}
+								}
+								$childNode->nodeValue = $content[1];
+							break;
+						}
+					}
+				}
+			}
+		}
+		return $table;
+	}
+
+
 }

--- a/includes/LoopZip.php
+++ b/includes/LoopZip.php
@@ -20,7 +20,7 @@ class LoopZip {
 	
 	public static function handleLoopZip( $input, array $args, Parser $parser, PPFrame $frame ) {
         
-        global $wgParser, $wgUploadDirectory, $wgUploadPath, $wgServer, $wgOut;
+        global $wgUploadDirectory, $wgUploadPath;
         
         $loopzip = new LoopZip( $input, $args );
         $return = '';
@@ -37,7 +37,7 @@ class LoopZip {
                 $scaleClass = 'responsive-iframe';
             
                 if ( $loopzip->scale ) {
-                    $wgOut->addModules("skins.loop-resizer.js");
+                    $parser->getOutput()->addModules("skins.loop-resizer.js");
                     $scaleClass = "scale-frame";
                 }
 

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1855,7 +1855,39 @@
 
 	<!-- Loop NoPrint-->
 	<xsl:template match="extension[@extension_name='loop_noprint']">
-		<fo:block></fo:block>				
+		<fo:block></fo:block>
+		<xsl:choose>
+			<xsl:when test="./descendant::extension[@extension_name='loop_table']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_table']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+			<xsl:when test="./descendant::extension[@extension_name='loop_figure']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_figure']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+			<xsl:when test="./descendant::extension[@extension_name='loop_listing']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_listing']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+			<xsl:when test="./descendant::extension[@extension_name='loop_formula']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_formula']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+			<xsl:when test="./descendant::extension[@extension_name='loop_task']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_task']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+			<xsl:when test="./descendant::extension[@extension_name='loop_media']"><fo:block>
+				<xsl:attribute name="id">
+					<xsl:text>id</xsl:text><xsl:value-of select="./descendant::extension[@extension_name='loop_media']/@id"></xsl:value-of>
+				</xsl:attribute></fo:block>
+			</xsl:when>
+		</xsl:choose>
 	</xsl:template>
 	
 	<!-- Loop Score -->

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -655,7 +655,7 @@
 				<xsl:if test="ancestor::extension[@extension_name='loop_area']">
 					<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
 				</xsl:if>
-				<fo:table table-layout="fixed" content-width="150mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse" padding-start="0pt" padding-end="0pt" padding-top="4mm" padding-bottom="4mm"  padding-right="0pt">
+				<fo:table keep-together.within-page="always" table-layout="fixed" content-width="150mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse" padding-start="0pt" padding-end="0pt" padding-top="4mm" padding-bottom="4mm"  padding-right="0pt">
 					<!-- <xsl:attribute name="id"><xsl:text>object</xsl:text><xsl:value-of select="@id"></xsl:value-of></xsl:attribute> -->
 					<fo:table-column column-number="1" column-width="0.4mm"/>
 					<fo:table-column column-number="2">
@@ -1883,6 +1883,23 @@
 		</fo:block>		
 	</xsl:template>
 
+	<xsl:template match="extension[@extension_name='loop_areaa']">
+
+		<!-- ICON IMG -->
+				
+		<fo:block border-left="solid 2pt black">
+			<fo:float float="left" font-size="25pt" padding-bottom="2mm" margin-left="-25pt" margin-top="1.6mm" >
+			<fo:block border-left="solid 2pt black">
+					<xsl:choose> <!-- todo: trying to find a way to do this a much shorter way -->
+						<xsl:when test="@type!=''"><xsl:value-of select="$icon_task"></xsl:value-of></xsl:when>
+					</xsl:choose>
+		</fo:block>		
+			</fo:float>	
+			<xsl:apply-templates/>
+		</fo:block>		
+	</xsl:template>
+
+
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">
 		<fo:table keep-together.within-page="auto" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
@@ -2961,31 +2978,33 @@
 		</fo:list-item>
 	</xsl:template>	
 	
-	<xsl:template match="table">
-		<fo:table table-layout="auto" border-style="solid" border-width="0.5pt" border-color="black" border-collapse="collapse" padding="0.6pt" space-after="12.5pt">
-				<fo:table-body>
-					<xsl:apply-templates></xsl:apply-templates>
-				</fo:table-body>
-		</fo:table>
-	</xsl:template>
+<xsl:template match="table">
+   <fo:table table-layout="auto" border-style="solid" border-width="0.5pt" border-color="black" border-collapse="collapse" padding="0.6pt" space-after="12.5pt">
+   		<fo:table-body>
+    		<xsl:apply-templates></xsl:apply-templates>
+    	</fo:table-body>
+   </fo:table>
+</xsl:template>
 
-	<xsl:template match="tablerow">
+<xsl:template match="tablerow">
 
-		<fo:table-row keep-together.within-column="auto">
-			<xsl:apply-templates></xsl:apply-templates>
-		</fo:table-row>
+	<fo:table-row keep-together.within-column="auto">
+		<xsl:apply-templates></xsl:apply-templates>
+	</fo:table-row>
 
-	</xsl:template>
+</xsl:template>
 
     <xsl:template match="tablecell">
         <fo:table-cell>
+		
+			
         	<xsl:attribute name="padding">3pt</xsl:attribute>
         	<xsl:attribute name="border-style">solid</xsl:attribute>
         	<xsl:attribute name="border-width">0.5pt</xsl:attribute>
         	<xsl:attribute name="border-color">black</xsl:attribute>
         	<xsl:attribute name="border-collapse">collapse</xsl:attribute>
 			
-			<!-- <xsl:call-template name="css-style-attributes"></xsl:call-template> -->
+			<xsl:call-template name="css-style-attributes"></xsl:call-template>
 			
 			
         	<xsl:if test="@colspan">
@@ -2997,6 +3016,9 @@
 		   	                	
         	    	                	
         		<fo:block keep-together.within-column="auto">
+					<xsl:if test="ancestor::extension[@extension_name='loop_area']">
+						<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
+					</xsl:if>
         			<xsl:apply-templates></xsl:apply-templates>
 			</fo:block>
 			
@@ -3011,7 +3033,7 @@
         	<xsl:attribute name="border-color">black</xsl:attribute>
         	<xsl:attribute name="border-collapse">collapse</xsl:attribute>
 			
-			<!-- <xsl:call-template name="css-style-attributes"></xsl:call-template> -->
+			<xsl:call-template name="css-style-attributes"></xsl:call-template>
 			
         	<xsl:if test="@colspan">
 				<xsl:attribute name="number-columns-spanned"><xsl:value-of select="@colspan"></xsl:value-of></xsl:attribute>
@@ -3020,13 +3042,23 @@
 				<xsl:attribute name="number-rows-spanned"><xsl:value-of select="@rowspan"></xsl:value-of></xsl:attribute>
         	</xsl:if>        	           	        	
         	
-			<fo:block font-weight="bold" >
+        	<!-- 
+			<fo:block font-weight="bold" break-before="column">
         			<xsl:apply-templates></xsl:apply-templates>
+			</fo:block>
+ 			-->
+			<fo:block font-weight="bold" >
+				<xsl:if test="ancestor::extension[@extension_name='loop_area']">
+					<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
+				</xsl:if>
+				<xsl:apply-templates></xsl:apply-templates>
 			</fo:block>		
 		
         </fo:table-cell>
-    </xsl:template>
-
+    </xsl:template>	
+	
+	
+	
 	<xsl:template name="css-style-attributes">
 		<xsl:variable name="cssentries">
 			<xsl:call-template name="str:tokenize">
@@ -3075,6 +3107,9 @@
 					<xsl:value-of select="$cssvalue"/>
 				</xsl:attribute>
 			</xsl:when>
+			<xsl:when test="$csskey='width'">
+				
+			</xsl:when>
 			<xsl:when test="$csskey='text-align'">
 				<xsl:attribute name="text-align">
 					<xsl:choose>
@@ -3089,10 +3124,70 @@
 						</xsl:otherwise>
 					</xsl:choose>
 				</xsl:attribute>
-			</xsl:when>			
+			</xsl:when>		
+			<xsl:otherwise>
+			</xsl:otherwise>	
 		</xsl:choose>
+	</xsl:template>	
+
+	<xsl:template name="str:tokenize">
+	  <xsl:param name="string" select="''" />
+	  <xsl:param name="delimiters" select="' &#x9;&#xA;'" />
+	  <xsl:choose>
+		<xsl:when test="not($string)" />
+		<xsl:when test="not($delimiters)">
+		  <xsl:call-template name="str:_tokenize-characters">
+			<xsl:with-param name="string" select="$string" />
+		  </xsl:call-template>
+		</xsl:when>
+		<xsl:otherwise>
+		  <xsl:call-template name="str:_tokenize-delimiters">
+			<xsl:with-param name="string" select="$string" />
+			<xsl:with-param name="delimiters" select="$delimiters" />
+		  </xsl:call-template>
+		</xsl:otherwise>
+	  </xsl:choose>
 	</xsl:template>
-	
+
+	<xsl:template name="str:_tokenize-characters">
+	  <xsl:param name="string" />
+	  <xsl:if test="$string">
+		<token><xsl:value-of select="substring($string, 1, 1)" /></token>
+		<xsl:call-template name="str:_tokenize-characters">
+		  <xsl:with-param name="string" select="substring($string, 2)" />
+		</xsl:call-template>
+	  </xsl:if>
+	</xsl:template>
+
+	<xsl:template name="str:_tokenize-delimiters">
+	  <xsl:param name="string" />
+	  <xsl:param name="delimiters" />
+	  <xsl:variable name="delimiter" select="substring($delimiters, 1, 1)" />
+	  <xsl:choose>
+		<xsl:when test="not($delimiter)">
+		  <token><xsl:value-of select="$string" /></token>
+		</xsl:when>
+		<xsl:when test="contains($string, $delimiter)">
+		  <xsl:if test="not(starts-with($string, $delimiter))">
+			<xsl:call-template name="str:_tokenize-delimiters">
+			  <xsl:with-param name="string" select="substring-before($string, $delimiter)" />
+			  <xsl:with-param name="delimiters" select="substring($delimiters, 2)" />
+			</xsl:call-template>
+		  </xsl:if>
+		  <xsl:call-template name="str:_tokenize-delimiters">
+			<xsl:with-param name="string" select="substring-after($string, $delimiter)" />
+			<xsl:with-param name="delimiters" select="$delimiters" />
+		  </xsl:call-template>
+		</xsl:when>
+		<xsl:otherwise>
+		  <xsl:call-template name="str:_tokenize-delimiters">
+			<xsl:with-param name="string" select="$string" />
+			<xsl:with-param name="delimiters" select="substring($delimiters, 2)" />
+		  </xsl:call-template>
+		</xsl:otherwise>
+	  </xsl:choose>
+	</xsl:template>	
+
 	<xsl:template match="extension[@extension_name='loop_screenshot']">
 		
 		<xsl:variable name="page" select="ancestor::article/@id"/>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1843,13 +1843,13 @@
 
 	<!-- Loop Print-->
 	<xsl:template match="extension[@extension_name='loop_print']">
-		<fo:block >
-			<fo:block font-family="{$font_family}" color="{$accent_color}" font-size="6mm" text-align="center" padding-bottom="2mm">
+		 <fo:block >
+			<!--<fo:block font-family="{$font_family}" color="{$accent_color}" font-size="6mm" text-align="center" padding-bottom="2mm">
 				<xsl:value-of select="$icon_print"></xsl:value-of>
 			</fo:block>
-			<fo:block  padding="2mm" border-bottom="dashed 0.4mm {$accent_color}" border-top="dashed 0.4mm {$accent_color}">
+			<fo:block  padding="2mm" border-bottom="dashed 0.4mm {$accent_color}" border-top="dashed 0.4mm {$accent_color}"> -->
 				<xsl:apply-templates></xsl:apply-templates>
-			</fo:block>
+			<!-- </fo:block> -->
 		</fo:block>
 	</xsl:template>
 

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1885,7 +1885,7 @@
 
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">
-		<fo:table keep-together.within-page="always" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
+		<fo:table keep-together.within-page="auto" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
 			<fo:table-column column-number="1" column-width="10mm" />
 			<fo:table-column column-number="2" column-width="6mm" margin-right="-10mm"/>
 			<fo:table-column column-number="3" column-width="146mm"/>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -687,6 +687,9 @@
 								</xsl:choose> 
 								<fo:block text-align="left" margin-bottom="1mm">
 									<xsl:choose> 
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+											<xsl:attribute name="margin-left">0mm</xsl:attribute>
+										</xsl:when>
 										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
 											<xsl:attribute name="margin-left">13mm</xsl:attribute>
 										</xsl:when>
@@ -705,7 +708,7 @@
 								<fo:table-cell width="150mm" text-align="left" padding-right="2mm">
 								<xsl:choose> 
 									<xsl:when test="ancestor::extension[@extension_name='loop_area']">
-										<xsl:attribute name="padding-left">13mm</xsl:attribute>
+										<!-- <xsl:attribute name="padding-left">13mm</xsl:attribute> -->
 									</xsl:when>
 									<xsl:otherwise>
 										<xsl:attribute name="padding-left">1mm</xsl:attribute>
@@ -716,9 +719,17 @@
 									</xsl:if>
 									<xsl:call-template name="font_object_title"></xsl:call-template>
 									<fo:block text-align="left">
-									<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-										<xsl:attribute name="margin-left">1mm</xsl:attribute>
-									</xsl:if>
+									<xsl:choose> 
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+											<xsl:attribute name="margin-left">1mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
+											<xsl:attribute name="margin-left">13mm</xsl:attribute>
+										</xsl:when>
+										<xsl:otherwise>
+											<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
+										</xsl:otherwise>
+									</xsl:choose> 
 									<xsl:if test="count($object[@render]) = 0 or $object[@render!='title']">						
 										<xsl:choose>
 											<xsl:when test="$object[@extension_name='loop_figure']">
@@ -2979,9 +2990,33 @@
 	</xsl:template>	
 	
 <xsl:template match="table">
+		<xsl:variable name="looparea">
+			<xsl:choose>
+				<xsl:when test="ancestor::extension[@extension_name='loop_area']">true</xsl:when>		
+				<xsl:otherwise>false</xsl:otherwise>	
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="loopspoiler">
+			<xsl:choose>
+				<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">true</xsl:when>	
+				<xsl:when test="ancestor::extension[@extension_name='spoiler']">true</xsl:when>		
+				<xsl:otherwise>false</xsl:otherwise>	
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="loopobject">
+			<xsl:choose>
+				<xsl:when test="ancestor::extension[@extension_name='loop_figure']">true</xsl:when>	
+				<xsl:when test="ancestor::extension[@extension_name='loop_table']">true</xsl:when>		
+				<xsl:otherwise>false</xsl:otherwise>	
+			</xsl:choose>
+		</xsl:variable>
+	<xsl:apply-templates select="php:function('LoopXsl::xsl_transform_table_attributes', ., $looparea, $loopspoiler, $loopobject)" mode="xsl_table"></xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="table" mode="xsl_table">
    <fo:table table-layout="auto" border-style="solid" border-width="0.5pt" border-color="black" border-collapse="collapse" padding="0.6pt" space-after="12.5pt">
    		<fo:table-body>
-    		<xsl:apply-templates></xsl:apply-templates>
+			<xsl:apply-templates></xsl:apply-templates>
     	</fo:table-body>
    </fo:table>
 </xsl:template>
@@ -2996,8 +3031,6 @@
 
     <xsl:template match="tablecell">
         <fo:table-cell>
-		
-			
         	<xsl:attribute name="padding">3pt</xsl:attribute>
         	<xsl:attribute name="border-style">solid</xsl:attribute>
         	<xsl:attribute name="border-width">0.5pt</xsl:attribute>
@@ -3005,20 +3038,25 @@
         	<xsl:attribute name="border-collapse">collapse</xsl:attribute>
 			
 			<xsl:call-template name="css-style-attributes"></xsl:call-template>
-			
-			
+
         	<xsl:if test="@colspan">
 				<xsl:attribute name="number-columns-spanned"><xsl:value-of select="@colspan"></xsl:value-of></xsl:attribute>
         	</xsl:if>
         	<xsl:if test="@rowspan">
 				<xsl:attribute name="number-rows-spanned"><xsl:value-of select="@rowspan"></xsl:value-of></xsl:attribute>
         	</xsl:if>    
-		   	                	
-        	    	                	
         		<fo:block keep-together.within-column="auto">
-					<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-						<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
-					</xsl:if>
+					<xsl:choose> 
+						<xsl:when test="ancestor::table[@looparea!=''] and ancestor::table[@loopspoiler!='']">
+							<xsl:attribute name="margin-left">0mm</xsl:attribute>
+						</xsl:when>
+						<xsl:when test="ancestor::table[@looparea!=''] and ancestor::table[@loopobject!='']">
+							<xsl:attribute name="margin-left">0mm</xsl:attribute>
+						</xsl:when>
+						<xsl:when test="ancestor::table[@looparea!='']">
+							<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
+						</xsl:when>
+					</xsl:choose> 
         			<xsl:apply-templates></xsl:apply-templates>
 			</fo:block>
 			
@@ -3042,22 +3080,23 @@
 				<xsl:attribute name="number-rows-spanned"><xsl:value-of select="@rowspan"></xsl:value-of></xsl:attribute>
         	</xsl:if>        	           	        	
         	
-        	<!-- 
-			<fo:block font-weight="bold" break-before="column">
-        			<xsl:apply-templates></xsl:apply-templates>
-			</fo:block>
- 			-->
 			<fo:block font-weight="bold" >
-				<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-					<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
-				</xsl:if>
+				<xsl:choose> 
+					<xsl:when test="ancestor::table[@looparea!=''] and ancestor::table[@loopspoiler!='']">
+						<xsl:attribute name="margin-left">0mm</xsl:attribute>
+					</xsl:when>
+					<xsl:when test="ancestor::table[@looparea!=''] and ancestor::table[@loopobject!='']">
+						<xsl:attribute name="margin-left">0mm</xsl:attribute>
+					</xsl:when>
+					<xsl:when test="ancestor::table[@looparea!='']">
+						<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
+					</xsl:when>
+				</xsl:choose> 
 				<xsl:apply-templates></xsl:apply-templates>
 			</fo:block>		
 		
         </fo:table-cell>
     </xsl:template>	
-	
-	
 	
 	<xsl:template name="css-style-attributes">
 		<xsl:variable name="cssentries">

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1740,7 +1740,7 @@
 	
 	<!-- Loop Spoiler -->
 	<xsl:template name="spoiler">
-		<fo:block keep-together.within-page="always">
+		<fo:block keep-together.within-page="auto">
 			<fo:block font-weight="bold" width="145mm">
 				<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1.3mm" padding-right="1.3mm" padding-top="1.3mm" padding-bottom="1.5mm">
 


### PR DESCRIPTION
- Error Messages vereinheitlicht und reduziert
- Zip fix für Skalierung

**PDF**
- Tabellen können nun colspan und background color in PDF haben
- Spoiler und Areas brechen nun um
- Tabellen sehen nun immer gleich aus, egal ob in Area, Objekt, Spoiler (oder mehreres)
- Objekte in noprint-Tags verursachen keinen ID Fehler mehr
- Timeouts gesetzt
- XML-Debug Möglichkeiten geschaffen
