### PR TITLE
RSS-Feed

### DIFF
--- a/Loop.i18n.alias.php
+++ b/Loop.i18n.alias.php
@@ -32,7 +32,8 @@ $specialPageAliases['en'] = array(
 	'LoopBugReport' => array( 'Bugreport' ),
 	'LoopFeedback' => array( 'Feedback' ),
 	'LoopImprint' => array( 'Imprint' ),
-	'LoopPrivacy' => array( 'Privacy' )
+	'LoopPrivacy' => array( 'Privacy' ),
+	'LoopRSS' => array( 'LoopRSS' )
 	);
 
 $specialPageAliases['de'] = array(
@@ -59,7 +60,8 @@ $specialPageAliases['de'] = array(
 	'LoopBugReport' => array( 'Fehler melden' ),
 	'LoopFeedback' => array( 'Feedback' ),
 	'LoopImprint' => array( 'Impressum' ),
-	'LoopPrivacy' => array( 'Datenschutz' )
+	'LoopPrivacy' => array( 'Datenschutz' ),
+	'LoopRSS' => array( 'LoopRSS' )
 	);
 	
 $specialPageAliases['sv'] = array(
@@ -86,7 +88,8 @@ $specialPageAliases['sv'] = array(
 	'LoopBugReport' => array( 'Rapportera fel' ),
 	'LoopFeedback' => array( 'Feedback' ),
 	'LoopImprint' => array( 'Imprint' ),
-	'LoopPrivacy' => array( 'Privacy' )
+	'LoopPrivacy' => array( 'Privacy' ),
+	'LoopRSS' => array( 'LoopRSS' )
 	);
 
 $specialPageAliases['es'] = array(
@@ -112,7 +115,8 @@ $specialPageAliases['es'] = array(
 	'LoopExportPdfTest' => array( 'Prueba del PDF por página' ),
 	'LoopBugReport' => array( 'Reportar error' ),
 	'LoopImprint' => array( 'Imprint' ),
-	'LoopPrivacy' => array( 'Privacy' )
+	'LoopPrivacy' => array( 'Privacy' ),
+	'LoopRSS' => array( 'LoopRSS' )
 );
 
 

--- a/extension.json
+++ b/extension.json
@@ -111,7 +111,8 @@
 		"ApiLoopFeedbackOverview": "includes/LoopFeedbackApi.php",
 		"LoopAccordion": "includes/LoopAccordion.php",
 		"SpecialLoopImprint": "includes/Loop.php",
-		"SpecialLoopPrivacy": "includes/Loop.php"
+		"SpecialLoopPrivacy": "includes/Loop.php",
+		"SpecialLoopRSS": "includes/LoopRSS.php"
 	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates":[
@@ -201,7 +202,8 @@
 		"LoopBugReport": "SpecialLoopBugReport",
 		"LoopFeedback": "SpecialLoopFeedback",
 		"LoopImprint": "SpecialLoopImprint",
-		"LoopPrivacy": "SpecialLoopPrivacy"
+		"LoopPrivacy": "SpecialLoopPrivacy",
+		"LoopRSS": "SpecialLoopRSS"
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
@@ -974,6 +976,10 @@
 		"LoopExternalImprintUrl": {
 			"value": "",
 			"description" : "Url for fetching Imprint data"
+		},
+		"LoopUnprotectedRSS": {
+			"value": true,
+			"description" : "Enable RSS feed page without login"
 		}
 	},
 	"LogTypes": [ "loopexport" ],

--- a/extension.json
+++ b/extension.json
@@ -975,10 +975,14 @@
 		},
 		"LoopExternalImprintUrl": {
 			"value": "",
-			"description" : "Url for fetching Imprint data"
+			"description" : "Url for fetching imprint data"
+		},
+		"LoopRSSToken": {
+			"value": "",
+			"description" : "Token for viewing RSS without logging in"
 		},
 		"LoopUnprotectedRSS": {
-			"value": true,
+			"value": false,
 			"description" : "Enable RSS feed page without login"
 		}
 	},

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -28,6 +28,7 @@
 	"loopstructure-default-newpage-content": "Dies ist eine neu erstellte Seite.",
 	"loopimprint": "Impressum",
 	"loopprivacy": "Datenschutz",
+	"looprss": "RSS Feed",
 
 	"loopsettings": "LOOP-Einstellungen",
 	"loopsettings-specialpage-title": "LOOP-Einstellungen",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -94,6 +94,7 @@
 	"loopsettings-captcha-addurl-label": "... bei einer Bearbeitung, mit der externe Links hinzugefügt werden",
 	"loopsettings-captcha-createaccount-label": "... beim Anlegen eines Accounts",
 	"loopsettings-captcha-badlogin-label": "... bei einem zweiten Loginversuch nach Fehlanmeldung",
+	"loopsettings-captcha-bugreport-label": "... beim Ausfüllen des Fehler melden Formulars",
 
 	"loopsettings-headline-feedback": "Feedback",
 	"loopsettings-feedback-level-label": "Art der Erhebung",
@@ -104,6 +105,10 @@
 	"loopsettings-feedback-mode-always": "Auf jeder Seite",
 	"loopsettings-feedback-mode-last_sublevel": "Auf dem letzten Unterkapitel",
 	"loopsettings-feedback-mode-second_half": "In der zweiten Hälfte",
+
+	"loopsettings-headline-rss": "RSS-Feed",
+	"loopsettings-rss-text": "Kopieren Sie den kompletten untenstehenden Link in Ihren RSS-Reader.",
+	"loopsettings-rss-unprotected-label": "Zugang zum Feed auch ohne Token oder Login zulassen (nicht empfohlen)",
 
 	"loopexport-specialpage-title": "Loop exportieren",
 	"loopexport": "Loop exportieren",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -28,6 +28,7 @@
 	"loopstructure-default-newpage-content": "This is a new page.",
 	"loopimprint": "Imprint",
 	"loopprivacy": "Privacy",
+	"looprss": "RSS Feed",
 
 	"loopsettings" : "LOOP settings",
 	"loopsettings-specialpage-title" : "LOOP settings",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -94,6 +94,7 @@
 	"loopsettings-captcha-addurl-label": "... triggered on a page save that would add one or more URLs to the page",
 	"loopsettings-captcha-createaccount-label": "... triggered on creation of a new account",
 	"loopsettings-captcha-badlogin-label": "... triggered on the next login attempt after a failed one.",
+	"loopsettings-captcha-bugreport-label": "... triggered on the bug report page",
 
 	"loopsettings-headline-feedback": "Feedback",
 	"loopsettings-feedback-level-label": "Type of collection",
@@ -104,6 +105,10 @@
 	"loopsettings-feedback-mode-always": "On every page",
 	"loopsettings-feedback-mode-last_sublevel": "On the last subsection",
 	"loopsettings-feedback-mode-second_half": "In the second half",
+
+	"loopsettings-headline-rss": "RSS-Feed",
+	"loopsettings-rss-text": "Copy the link below into your RSS reaser.",
+	"loopsettings-rss-unprotected-label": "Allow reading the feed without token or login (not recommented)",
 
 	"loopexport-specialpage-title" : "Loop Export",
 	"loopexport": "Loop Export",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -94,6 +94,11 @@
 	"loopsettings-captcha-addurl-label": "... activado durante la edición para añadir enlaces externos",
 	"loopsettings-captcha-createaccount-label": "... activado para la creación de una cuenta nueva",
 	"loopsettings-captcha-badlogin-label": "... activado en el siguiente intento de inicio de sesión, después de haber fallado el primer intento.",
+	"loopsettings-captcha-bugreport-label": "... triggered on the bug report page",
+
+	"loopsettings-headline-rss": "RSS-Feed",
+	"loopsettings-rss-text": "Copy the link below into your RSS reaser.",
+	"loopsettings-rss-unprotected-label": "Allow reading the feed without token or login (not recommented)",
 
 	"loopexport-specialpage-title" : "Exportación del LOOP",
 	"loopexport": "Exportación del LOOP",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -28,6 +28,7 @@
 	"loopstructure-default-newpage-content": "Esta es una página nueva.",
 	"loopimprint": "Imprint",
 	"loopprivacy": "Privacy",
+	"looprss": "RSS Feed",
 
 	"loopsettings" : "Configuración del LOOP",
 	"loopsettings-specialpage-title" : "Configuración del LOOP",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -28,6 +28,7 @@
 	"loopstructure-default-newpage-content": "Standard content for new pages",
 	"loopimprint": "Imprint special page title",
 	"loopprivacy": "Privacy special page title",
+	"looprss": "RSS Feed special page title",
 
 	"loopsettings" : "Name of the LOOP settings special page in special:loopsettings",
 	"loopsettings-specialpage-title" : "Page title for LOOP Settings special page",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -94,6 +94,7 @@
 	"loopsettings-captcha-addurl-label": "... triggered on a page save that would add one or more URLs to the page",
 	"loopsettings-captcha-createaccount-label": "... triggered on creation of a new account",
 	"loopsettings-captcha-badlogin-label": "... triggered on the next login attempt after a failed one.",
+	"loopsettings-captcha-bugreport-label": "... triggered on the bug report page",
 
 	"loopsettings-headline-feedback": "Feedback",
 	"loopsettings-feedback-level-label": "Type of collection",
@@ -104,6 +105,10 @@
 	"loopsettings-feedback-mode-always": "On every page",
 	"loopsettings-feedback-mode-last_sublevel": "On the last subsection",
 	"loopsettings-feedback-mode-second_half": "In the second half",
+
+	"loopsettings-headline-rss": "RSS-Feed headline",
+	"loopsettings-rss-text": "Tell the people where to put the link below, their rss reader.",
+	"loopsettings-rss-unprotected-label": "Setting for unprotected rss access",
 
 	"loopexport-specialpage-title" : "Page title for Loop Export special page",
 	"loopexport": "Name of Specialpage Export in List of Specialpages",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -94,6 +94,7 @@
 	"loopsettings-captcha-addurl-label": "... när externa länkar lägs till",
 	"loopsettings-captcha-createaccount-label": "... vid registrering",
 	"loopsettings-captcha-badlogin-label": "... när inloggning gick fel",
+	"loopsettings-captcha-bugreport-label": "... triggered on the bug report page",
 
 	"loopsettings-headline-feedback": "Feedback",
 	"loopsettings-feedback-level-label": "Typ av undersökning",
@@ -104,6 +105,10 @@
 	"loopsettings-feedback-mode-always": "På alla sidor",
 	"loopsettings-feedback-mode-last_sublevel": "På det sista underavsnittet",
 	"loopsettings-feedback-mode-second_half": "Under den andra halvan",
+
+	"loopsettings-headline-rss": "RSS-Feed",
+	"loopsettings-rss-text": "Kopera länken nedan till ditt RSS reader.",
+	"loopsettings-rss-unprotected-label": "Tillåt läsning av RSS utan token eller inloggning (rekommenderas inte)",
 
 	"loopexport-specialpage-title": "Export",
 	"loopexport": "Export",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -28,6 +28,7 @@
 	"loopstructure-default-newpage-content": "Den här är en ny sida.",
 	"loopimprint": "Imprint",
 	"loopprivacy": "Privacy",
+	"looprss": "RSS Feed",
 
 	"loopsettings": "LOOP-Inställningar",
 	"loopsettings-specialpage-title": "LOOP-Inställningar",

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -104,9 +104,11 @@ class Loop {
 				$wgCaptchaTriggers["addurl"] = ( !isset( $data['lset_captchaddurl'] ) ? $wgCaptchaTriggers["addurl"] : boolval( $data['lset_captchaddurl'] ) );
 				$wgCaptchaTriggers["createaccount"] = ( !isset( $data['lset_captchacreateaccount'] ) ? $wgCaptchaTriggers["createaccount"] : boolval( $data['lset_captchacreateaccount'] ) );
 				$wgCaptchaTriggers["badlogin"] = ( !isset( $data['lset_captchabadlogin'] ) ? $wgCaptchaTriggers["badlogin"] : boolval( $data['lset_captchabadlogin'] ) );
+				$wgCaptchaTriggers["bugreport"] = ( !isset( $data['lset_captchabugreport'] ) ? $wgCaptchaTriggers["bugreport"] : boolval( $data['lset_captchabugreport'] ) );
 				$wgLoopBugReportEmail = ( !isset( $data['lset_ticketemail'] ) ? $wgLoopBugReportEmail : $data['lset_ticketemail'] );
 				$wgLoopFeedbackLevel = ( !isset( $data['lset_feedbacklevel'] ) ? $wgLoopFeedbackLevel : $data['lset_feedbacklevel'] );
 				$wgLoopFeedbackMode = ( !isset( $data['lset_feedbackmode'] ) ? $wgLoopFeedbackMode : $data['lset_feedbackmode'] );
+				$wgLoopUnprotectedRSS = ( !isset( $data['lset_rssunprotected'] ) ? $wgLoopUnprotectedRSS : $data['lset_rssunprotected'] );
 			}
 
 		}
@@ -163,7 +165,7 @@ class Loop {
 		# Lingo configuration
 		$wgexLingoPage = 'MediaWiki:LoopTerminologyPage';
 		$wgexLingoDisplayOnce = true;
-
+		
 		# Captcha configuration
 		$wgCaptchaClass = 'ReCaptchaNoCaptcha';
 		if ( empty( $wgReCaptchaSecretKey ) && empty( $wgReCaptchaSiteKey ) ) {
@@ -171,8 +173,11 @@ class Loop {
 			$wgCaptchaTriggers["edit"] = false;
 			$wgCaptchaTriggers["create"] = false;
 			$wgCaptchaTriggers["addurl"] = false;
+			$wgCaptchaTriggers["sendemail"] = false;
 			$wgCaptchaTriggers["createaccount"] = false;
 			$wgCaptchaTriggers["badlogin"] = false;
+			$wgCaptchaTriggers["badloginperuser"] = false;
+			$wgCaptchaTriggers["bugreport"] = false;
 		}
 
 		return true;

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -117,7 +117,7 @@ class Loop {
 
 		$wgWhitelistRead = is_array( $wgWhitelistRead ) ? $wgWhitelistRead : array();
 		$wgWhitelistRead = array_merge ( $wgWhitelistRead, [ "Spezial:Impressum", "Spezial:Datenschutz", "Special:Imprint", "Special:Privacy", "Especial:Imprint", "Especial:Privacy", "Speciel:Imprint", "Speciel:Privacy"] );
-		$wgWhitelistRead = $wgLoopUnprotectedRSS ? array_merge ( $wgWhitelistRead, [ "Spezial:LoopRSS", "Special:LoopRSS", "Especial:LoopRSS", "Speciel:LoopRSS"] ) : $wgWhitelistRead;
+		$wgWhitelistRead = array_merge ( $wgWhitelistRead, [ "Spezial:LoopRSS", "Special:LoopRSS", "Especial:LoopRSS", "Speciel:LoopRSS"] );
 		$wgWhitelistRead[] = $wgLoopImprintLink;
 		$wgWhitelistRead[] = $wgLoopPrivacyLink;
 		$wgWhitelistRead[] = "MediaWiki:Common.js";

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -53,7 +53,7 @@ class Loop {
 		$wgLogRestrictions, $wgFileExtensions, $wgLoopObjectNumbering, $wgLoopNumberingType, $wgExtraNamespaces, $wgLoopLiteratureCiteType,
 		$wgContentHandlers, $wgexLingoPage, $wgexLingoDisplayOnce, $wgLoopCustomLogo, $wgLoopExtraFooter, $wgLoopExtraSidebar, 
 		$wgLoopPrivacyLink, $wgLoopSocialIcons, $wgCaptchaTriggers, $wgCaptchaClass, $wgReCaptchaSiteKey, $wgReCaptchaSecretKey,
-		$wgLoopBugReportEmail, $wgLoopFeedbackLevel, $wgLoopFeedbackMode;
+		$wgLoopBugReportEmail, $wgLoopFeedbackLevel, $wgLoopFeedbackMode, $wgLoopUnprotectedRSS;
 		
 		#override preSaveTransform function by copying WikitextContent and adding a Hook
 		$wgContentHandlers[CONTENT_MODEL_WIKITEXT] = 'LoopWikitextContentHandler';
@@ -117,6 +117,7 @@ class Loop {
 
 		$wgWhitelistRead = is_array( $wgWhitelistRead ) ? $wgWhitelistRead : array();
 		$wgWhitelistRead = array_merge ( $wgWhitelistRead, [ "Spezial:Impressum", "Spezial:Datenschutz", "Special:Imprint", "Special:Privacy", "Especial:Imprint", "Especial:Privacy", "Speciel:Imprint", "Speciel:Privacy"] );
+		$wgWhitelistRead = $wgLoopUnprotectedRSS ? array_merge ( $wgWhitelistRead, [ "Spezial:LoopRSS", "Special:LoopRSS", "Especial:LoopRSS", "Speciel:LoopRSS"] ) : $wgWhitelistRead;
 		$wgWhitelistRead[] = $wgLoopImprintLink;
 		$wgWhitelistRead[] = $wgLoopPrivacyLink;
 		$wgWhitelistRead[] = "MediaWiki:Common.js";

--- a/includes/LoopRSS.php
+++ b/includes/LoopRSS.php
@@ -1,0 +1,66 @@
+<?php
+/**
+  * @description RSS Feed special page
+  * @ingroup Extensions
+  * @author Dennis Krohn @krohnden <dennis.krohn@th-luebeck.de>
+  */
+  
+  if ( !defined( 'MEDIAWIKI' ) ) {
+	die( "This file cannot be run standalone.\n" );
+}
+
+use MediaWiki\MediaWikiServices;
+
+class SpecialLoopRSS extends SpecialPage {
+
+	function __construct() {
+		parent::__construct( 'LoopRSS' );
+	}
+
+	function execute( $par ) {
+        
+        global $wgLoopUnprotectedRSS;
+		$out = $this->getOutput();
+		$request = $this->getRequest();
+		$user = $this->getUser();
+		Loop::handleLoopRequest( $out, $request, $user ); #handle editmode
+		$out->setPageTitle( $this->msg( "privacy" ) );
+
+        if ( $user->isLoggedIn() || $wgLoopUnprotectedRSS ) {
+
+            global $wgCanonicalServer, $wgScriptPath;
+            $url = $wgCanonicalServer . $wgScriptPath . "/api.php";
+
+            $params = "";
+            if ( ! $user->isLoggedIn() && class_exists( "LoopSessionProvider" ) ) { 
+                $params .= LoopSessionProvider::getApiPermission();
+            } else {
+                $this->setHeaders();
+                $out->addHTML($this->msg("specialpage-no-permission"));
+                return;
+            }
+            $params .= "hidebots=1&namespace=2&invert=1&urlversion=1&days=30&limit=20&action=feedrecentchanges&feedformat=atom";
+            
+            $url .= "?" . $params;
+            $httpRequest = MWHttpRequest::factory( $url );
+            $status = $httpRequest->execute();
+            $result = $httpRequest->getContent();
+            
+            $this->getOutput()->disable();
+            wfResetOutputBuffers();
+
+            header("Last-Modified: " . date("D, d M Y H:i:s T", strtotime(time())));
+            header("Content-Type: application/xml; charset=utf-8");
+            echo $result;
+
+        } else {
+            $this->setHeaders();
+			$out->addHTML($this->msg("specialpage-no-permission"));
+        }
+
+    }
+    
+	protected function getGroupName() {
+		return 'loop';
+	}
+}

--- a/includes/LoopRSS.php
+++ b/includes/LoopRSS.php
@@ -61,7 +61,7 @@ class SpecialLoopRSS extends SpecialPage {
         if ( class_exists( "LoopSessionProvider" ) ) { 
             $params .= LoopSessionProvider::getApiPermission();
         } else {
-            if ( !$user->isLoggedIn() ) {
+            if ( !$this->getUser()->isLoggedIn() ) {
                 $this->setHeaders();
                 $this->getOutput()->addHTML($this->msg("specialpage-no-permission"));
                 return;

--- a/includes/LoopRSS.php
+++ b/includes/LoopRSS.php
@@ -61,9 +61,11 @@ class SpecialLoopRSS extends SpecialPage {
         if ( class_exists( "LoopSessionProvider" ) ) { 
             $params .= LoopSessionProvider::getApiPermission();
         } else {
-            $this->setHeaders();
-            $this->getOutput()->addHTML($this->msg("specialpage-no-permission"));
-            return;
+            if ( !$user->isLoggedIn() ) {
+                $this->setHeaders();
+                $this->getOutput()->addHTML($this->msg("specialpage-no-permission"));
+                return;
+            }
         }
         $params .= "hidebots=1&namespace=2&invert=1&urlversion=1&days=30&limit=20&action=feedrecentchanges&feedformat=atom";
         

--- a/includes/LoopRSS.php
+++ b/includes/LoopRSS.php
@@ -26,7 +26,7 @@ class SpecialLoopRSS extends SpecialPage {
 		Loop::handleLoopRequest( $out, $request, $user ); #handle editmode
 		$out->setPageTitle( $this->msg( "looprss" ) );
         $token = $request->getText( 't' );
-
+        
         if ( $user->isLoggedIn() ) {
 
             $this->outputRecentChanges();
@@ -61,7 +61,6 @@ class SpecialLoopRSS extends SpecialPage {
         if ( class_exists( "LoopSessionProvider" ) ) { 
             $params .= LoopSessionProvider::getApiPermission();
         } else {
-            dd( $this->getUser()->isLoggedIn() , class_exists( "LoopSessionProvider" ) );
             $this->setHeaders();
             $this->getOutput()->addHTML($this->msg("specialpage-no-permission"));
             return;

--- a/includes/LoopSettings.php
+++ b/includes/LoopSettings.php
@@ -960,25 +960,19 @@ class SpecialLoopSettings extends SpecialPage {
                     
 					$html .= '<div class="form-row mb-4">';
                    
-                    global $wgCanonicalServer, $wgArticlePath, $wgLoopRssToken;
+                    global $wgCanonicalServer, $wgArticlePath, $wgLoopRSSToken;
                     $html .= '<div class="col-6">';
                     $html .= '<h3>' . $this->msg( 'loopsettings-headline-rss' )->text() . '</h3>'; 
                     $html .= '<p>' . $this->msg( 'loopsettings-rss-text' )->text() . '</p>'; 
-                    $rsslink = $wgCanonicalServer . str_replace( "$1", "Special:", $wgArticlePath) . "LoopRSS?t=" . $wgLoopRssToken; 
+                    $rsslink = $wgCanonicalServer . str_replace( "$1", "Special:", $wgArticlePath) . "LoopRSS?t=" . $wgLoopRSSToken; 
                     $html .= '<input id="rss-link" class="w-75 float-left mb-2 form-control" type="text" value="'.$rsslink.'"></input>'; 
                     $html .= '<p  id="rss-link-btn" class="w-25 float-left mw-htmlform-submit mw-ui-button mw-ui-primary mw-ui-progressive d-block">copy</p>';
                     $html .= '<div class="float-left">';
                     $html .= '<input type="checkbox" name="rss-unprotected" id="rss-unprotected" class="setting-input mr-1" ' . ( $currentLoopSettings->rssUnprotected == "rssUnprotected" ? 'checked' : '' ) .'>';
                     $html .= '<label for="rss-unprotected">'. $this->msg("loopsettings-rss-unprotected-label")->text().'</label>';
-                   
-                    
-                    
+
                     $html .= '</div>';
                     $html .= '</div>';
-
-
-                   
-
                     $html .= '</div>';
 				$html .= '</div>'; // end of tech-tab
 

--- a/includes/LoopSettings.php
+++ b/includes/LoopSettings.php
@@ -51,9 +51,11 @@ class LoopSettings {
     public $captchaAddurl; #wgCaptchaTriggers["addurl"]
     public $captchaCreateAccount; #wgCaptchaTriggers["createaccount"]
     public $captchaBadlogin; #wgCaptchaTriggers["badlogin"]
+    public $captchaBugReport; #wgCaptchaTriggers["bugreport"]
     public $bugReportEmail; #wgLoopBugReportEmail
     public $feedbackLevel; #wgLoopFeedbackLevel
     public $feedbackMode; #wgLoopFeedbackMode
+    public $rssUnprotected; #wgLoopUnprotectedRSS
 
     /**
      * Add settings to the database
@@ -98,9 +100,11 @@ class LoopSettings {
             'lset_captchaddurl' => $this->captchaAddurl,
             'lset_captchacreateaccount' => $this->captchaCreateAccount,
             'lset_captchabadlogin' => $this->captchaBadlogin,
+            'lset_captchabugreport' => $this->captchaBugReport,
             'lset_ticketemail' => $this->bugReportEmail,
             'lset_feedbacklevel' => $this->feedbackLevel,
-            'lset_feedbackmode' => $this->feedbackMode
+            'lset_feedbackmode' => $this->feedbackMode,
+            'lset_rssunprotected' => $this->rssUnprotected
         );
         
         $dbw = wfGetDB( DB_MASTER );
@@ -153,7 +157,7 @@ class LoopSettings {
         global $wgLoopImprintLink, $wgLoopPrivacyLink, $wgRightsText, $wgLoopRightsType, $wgRightsUrl, $wgRightsIcon, 
         $wgLoopCustomLogo, $wgLoopExtraFooter, $wgDefaultUserOptions, $wgLoopSocialIcons, $wgLoopObjectNumbering, 
         $wgLoopNumberingType, $wgLoopLiteratureCiteType, $wgLoopExtraSidebar, $wgCaptchaTriggers, $wgLoopBugReportEmail,
-        $wgLoopFeedbackLevel, $wgLoopFeedbackMode;
+        $wgLoopFeedbackLevel, $wgLoopFeedbackMode, $wgLoopUnprotectedRSS;
         
         # take values from presets in extension.json and LocalSettings if there is no DB entry
         $this->imprintLink = $wgLoopImprintLink;
@@ -193,9 +197,11 @@ class LoopSettings {
         $this->captchaAddurl = $wgCaptchaTriggers["addurl"];
         $this->captchaCreateAccount = $wgCaptchaTriggers["createaccount"];
         $this->captchaBadlogin = $wgCaptchaTriggers["badlogin"];
+        $this->captchaBugReport = $wgCaptchaTriggers["bugreport"];
         $this->bugReportEmail = $wgLoopBugReportEmail;
         $this->feedbackLevel = $wgLoopFeedbackLevel;
         $this->feedbackMode = $wgLoopFeedbackMode;
+        $this->rssUnprotected = $wgLoopUnprotectedRSS;
         
         if ( isset($row->lset_structure) ) {
             $this->imprintLink = isset( $data['lset_imprintlink'] ) ? $data['lset_imprintlink'] : $this->imprintLink;
@@ -235,9 +241,11 @@ class LoopSettings {
             $this->captchaAddurl =  isset( $data['lset_captchaddurl'] ) ? boolval($data['lset_captchaddurl']) : $this->captchaAddurl;
             $this->captchaCreateAccount =  isset( $data['lset_captchacreateaccount'] ) ? boolval($data['lset_captchacreateaccount']) : $this->captchaCreateAccount;
             $this->captchaBadlogin =  isset( $data['lset_captchabadlogin'] ) ? boolval($data['lset_captchabadlogin']) : $this->captchaBadlogin;
+            $this->captchaBugReport =  isset( $data['lset_captchabugreport'] ) ? boolval($data['lset_captchabugreport']) : $this->captchaBugReport;
             $this->bugReportEmail =  isset( $data['lset_ticketemail'] ) ? $data['lset_ticketemail'] : $this->bugReportEmail;
             $this->feedbackLevel =  isset( $data['lset_feedbacklevel'] ) ? $data['lset_feedbacklevel'] : $this->feedbackLevel;
             $this->feedbackMode =  isset( $data['lset_feedbackmode'] ) ? $data['lset_feedbackmode'] : $this->feedbackMode;
+            $this->rssUnprotected =  isset( $data['lset_rssunprotected'] ) ? boolval($data['lset_rssunprotected']) : $this->rssUnprotected;
         }
         
         return true;
@@ -510,6 +518,15 @@ class LoopSettings {
             array_push( $this->errors, wfMessage( 'loopsettings-error' ) . ': ' . wfMessage( 'loopsettings-captcha-badlogin-label' ) );
         }
 
+        # Captcha Bugreport
+        if ( $request->getText( 'captcha-bugreport' ) == 'on' ) { 
+            $this->captchaBugReport = true;
+        } elseif ( empty ( $request->getText( 'captcha-bugreport' ) ) ) {
+            $this->captchaBugReport = false;
+        } else {
+            array_push( $this->errors, wfMessage( 'loopsettings-error' ) . ': ' . wfMessage( 'loopsettings-captcha-bugreport-label' ) );
+        }
+
         # Bugreport Mail
         if  ( empty ( $request->getText( 'ticket-email' ) ) ) { 
             $this->bugReportEmail = null;
@@ -539,6 +556,15 @@ class LoopSettings {
             global $wgLoopFeedbackLevel;
             $this->feedbackLevel = $wgLoopFeedbackLevel;
             array_push( $this->errors, wfMessage( 'loopsettings-error' ) . ': ' . wfMessage( 'loopsettings-feedback-level-label' ) );
+        }
+
+        # RSS unprotected
+        if ( $request->getText( 'rss-unprotected' ) == 'on' ) { 
+            $this->rssUnprotected = true;
+        } elseif ( empty ( $request->getText( 'rss-unprotected' ) ) ) {
+            $this->rssUnprotected = false;
+        } else {
+            array_push( $this->errors, wfMessage( 'loopsettings-error' ) . ': ' . wfMessage( 'loopsettings-rss-unprotected-label' ) );
         }
 
         $this->addToDatabase();
@@ -925,10 +951,35 @@ class SpecialLoopSettings extends SpecialPage {
                     $html .= '<label for="captcha-createaccount">' . $this->msg( 'loopsettings-captcha-createaccount-label' )->text() . '</label></div>';
 					$html .= '<div><input type="checkbox" name="captcha-badlogin" id="captcha-badlogin" class="setting-input mr-1" ' . $captchaDisabled . " " . ( $currentLoopSettings->captchaBadlogin == "captchaBadlogin" ? 'checked' : '' ) .'>';
                     $html .= '<label for="captcha-badlogin">' . $this->msg( 'loopsettings-captcha-badlogin-label' ) . '</label></div>';
+                    $html .= '<div><input type="checkbox" name="captcha-bugreport" id="captcha-bugreport" class="setting-input mr-1" ' . $captchaDisabled . " " . ( $currentLoopSettings->captchaBugReport == "captchaBugReport" ? 'checked' : '' ) .'>';
+                    $html .= '<label for="captcha-bugreport">' . $this->msg( 'loopsettings-captcha-bugreport-label' ) . '</label></div>';
 					$html .= '<p><i>* '.$this->msg( "loopsettings-captcha-usergroup")->text().'</i></p>';
                     $html .= '</div>';
                     $html .= '</div>';
 
+                    
+					$html .= '<div class="form-row mb-4">';
+                   
+                    global $wgCanonicalServer, $wgArticlePath, $wgLoopRssToken;
+                    $html .= '<div class="col-6">';
+                    $html .= '<h3>' . $this->msg( 'loopsettings-headline-rss' )->text() . '</h3>'; 
+                    $html .= '<p>' . $this->msg( 'loopsettings-rss-text' )->text() . '</p>'; 
+                    $rsslink = $wgCanonicalServer . str_replace( "$1", "Special:", $wgArticlePath) . "LoopRSS?t=" . $wgLoopRssToken; 
+                    $html .= '<input id="rss-link" class="w-75 float-left mb-2 form-control" type="text" value="'.$rsslink.'"></input>'; 
+                    $html .= '<p  id="rss-link-btn" class="w-25 float-left mw-htmlform-submit mw-ui-button mw-ui-primary mw-ui-progressive d-block">copy</p>';
+                    $html .= '<div class="float-left">';
+                    $html .= '<input type="checkbox" name="rss-unprotected" id="rss-unprotected" class="setting-input mr-1" ' . ( $currentLoopSettings->rssUnprotected == "rssUnprotected" ? 'checked' : '' ) .'>';
+                    $html .= '<label for="rss-unprotected">'. $this->msg("loopsettings-rss-unprotected-label")->text().'</label>';
+                   
+                    
+                    
+                    $html .= '</div>';
+                    $html .= '</div>';
+
+
+                   
+
+                    $html .= '</div>';
 				$html .= '</div>'; // end of tech-tab
 
 				

--- a/resources/js/loop.special.settings.js
+++ b/resources/js/loop.special.settings.js
@@ -123,4 +123,32 @@ $( document ).ready( function () {
 
 		return this.infoForm;
 	};
+	/*
+	const source = document.querySelector('div.source');
+
+	source.addEventListener('copy', (event) => {
+		const selection = document.getSelection();
+		event.clipboardData.setData('text/plain', selection.toString().toUpperCase());
+		event.preventDefault();
+	});
+		function copy() {
+			var copyText = document.querySelector("#rss-link");
+			copyText.select();
+			document.execCommand("copy");
+			console.log(copyText);
+		}
+		document.querySelector("#rss-link-btn").addEventListener("click", copy);
+	*/
+	
+	var copyText = document.getElementById("rss-link");
+	var rsslink = copyText.value;
+	$( "#rss-link-btn" ).click( function() {
+		copyText.select();
+		copyText.setSelectionRange(0, 99999);
+		document.execCommand("copy");
+		console.log(copyText);
+	});
+	$( "#rss-link" ).on( "change keyup", function() {
+		$(this).val(rsslink);
+	});
 });

--- a/resources/js/loop.special.settings.js
+++ b/resources/js/loop.special.settings.js
@@ -123,22 +123,6 @@ $( document ).ready( function () {
 
 		return this.infoForm;
 	};
-	/*
-	const source = document.querySelector('div.source');
-
-	source.addEventListener('copy', (event) => {
-		const selection = document.getSelection();
-		event.clipboardData.setData('text/plain', selection.toString().toUpperCase());
-		event.preventDefault();
-	});
-		function copy() {
-			var copyText = document.querySelector("#rss-link");
-			copyText.select();
-			document.execCommand("copy");
-			console.log(copyText);
-		}
-		document.querySelector("#rss-link-btn").addEventListener("click", copy);
-	*/
 	
 	var copyText = document.getElementById("rss-link");
 	var rsslink = copyText.value;


### PR DESCRIPTION
- Der RSS-Feed ist nun über /loop/Spezial:LoopRSS verfügbar. (auf krohn [moodalis login])
- Ein neuer Token wurde hinzugefügt (neue Moodalis-Einstellung) - mit dem token kann man auch uneingeloggt den RSS-Feed sehen. Für alle mit Token ist der Feed offen (bot protection)
- Die Option, den Feed ganz unprotected zu halten, ist geblieben und ebenfalls in den Settings - Soll das eine Moodalis oder Loop-Setting sein? Oder schmeißen wir Unprotected raus, da wir den für alle gültigen Token haben?
- Ist man nicht eingeloggt UND hat den LoopAuthenticator nicht, funktioniert es auch mit token nicht, da man keine Berechtigung für die RecentChanges Seite hat.
- Der "copy" button soll noch ein kopieren-icon erhalten

- Der Captcha Trigger für die Bugreport Seite, an der Dustin gerade sitzt, wurde mit in die LoopSettings aufgenommen.