### PR TITLE
Unterschiedliche Fixes zum Export

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -984,6 +984,10 @@
 		"LoopUnprotectedRSS": {
 			"value": false,
 			"description" : "Enable RSS feed page without login"
+		},
+		"LoopExportDebug": {
+			"value": false,
+			"description" : "Enable debug mode for export - files are always newly created."
 		}
 	},
 	"LogTypes": [ "loopexport" ],

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -123,6 +123,7 @@
 	"loopexport-pdf-test-success": "Alle seiten funktionieren korrekt! Funktioniert die PDF dennoch nicht, [[Special:PurgeCache|löschen Sie den Cache]] und/oder kontaktieren Sie die/den AdministratorIn",
 	"loopexport-pdf-test-failure": "Auf der Seite [[$1]] ist ein Fehler aufgetreten. Sie können sich den Fehlerbericht unten ansehen.",
 	"loopexport-pdf-test-notice": "In der Trackingkategorie für $1 sind Seiten gelistet, die Fehler beinhalten. Sie können sich diese im Bearbeitungsmodus auf den jeweiligen Seiten ansehen.",
+	"loopexport-pdf-error": "Beim Erzeugen der PDF ist leider ein Fehler aufgetreten. ",
 
 	"right-loop-toc-edit": "Inhaltsverzeichnis bearbeiten",
 	"right-loop-export-pdf": "Export LOOP als PDF",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -123,6 +123,7 @@
 	"loopexport-pdf-test-success": "All pages were loaded successfully! If the PDF still doesn't work, [[Special:PurgeCache|delete the caches]] or contact your administrator.",
 	"loopexport-pdf-test-failure": "An error occurred on page [[$1]]. You can look at the error log at the end of this page.",
 	"loopexport-pdf-test-notice": "In the tracking category for $1 are pages listed that contain errors. Look at these pages in edit mode to find the sources.",
+	"loopexport-pdf-error": "An error occurred during the export of PDF. ",
 
 	"right-loop-toc-edit": "Edit toc",
 	"right-loop-export-pdf": "Export LOOP as PDF",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -113,6 +113,7 @@
 	"loopexport-pdf-test-success": "Todas las páginas han sido cargadas exitosamente! Si el PDF sigue sin funcionar, [[Special:PurgeCache|borre el caché]] o contacte a su administrador.",
 	"loopexport-pdf-test-failure": "Ha ocurrido un error en la página [[$1]]. Puede ver el registro de errores al final de esta página.",
 	"loopexport-pdf-test-notice": "La categoría de seguimiento por $1 enumera las páginas que contienen errores. Puede verlos en el modo de edición en las páginas respectivas.",
+	"loopexport-pdf-error": "An error occurred during the export of PDF. ",
 
 	"right-loop-toc-edit": "Editar índice de contenidos",
 	"right-loop-export-pdf": "Exportar LOOP como PDF",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -123,6 +123,7 @@
 	"loopexport-pdf-test-success": "Success message after testing pdf per-page. In case the pdf still does not work, a link to Special:PurgeCache should be added.",
 	"loopexport-pdf-test-failure": "Failure message after testing pdf per-page.",
 	"loopexport-pdf-test-notice": "Notice about pages in loop error tracking category. After testing pdf per-page.",
+	"loopexport-pdf-error": "Error message when PDF export does not work ",
 
 	"right-loop-toc-edit": "Right to edit toc",
 	"right-loop-export-pdf": "Right to export LOOP as PDF",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -123,6 +123,7 @@
 	"loopexport-pdf-test-success": "Inga fel hittades! Om PDF funker inte, [[Special:PurgeCache|rensa cachen]] eller kontaktera administratorn.",
 	"loopexport-pdf-test-failure": "På sidan [[$1]] uppstod ett fel. Du kan läsa loggen nedan.",
 	"loopexport-pdf-test-notice": "I trackingkategoriet för $1 finns sidor med fel. Titta på dem i regideringsmodus.",
+	"loopexport-pdf-error": "Ett fel uppstod vid exporten. ",
 
 	"right-loop-toc-edit": "Regidera innehåll",
 	"right-loop-export-pdf": "Export LOOP som PDF",

--- a/includes/Loop.php
+++ b/includes/Loop.php
@@ -289,21 +289,11 @@ class SpecialLoopImprint extends UnlistedSpecialPage {
 
 		if ( $wgLoopExternalImprintPrivacy && !empty ( $wgLoopExternalImprintUrl ) ) {
 
-			global $wgServerName;
-			
-			$url = $wgLoopExternalImprintUrl.'?loop=' . $wgServerName;
-			
-			$cha = curl_init();
-			curl_setopt($cha, CURLOPT_URL, ($url));
-			curl_setopt($cha, CURLOPT_ENCODING, "UTF-8" );
-			curl_setopt($cha, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($cha, CURLOPT_FOLLOWLOCATION, true);
-			$return = curl_exec($cha);
-			curl_close($cha);
+			$return = self::renderLoopImprintSpecialPage();
 	
 			if ( empty( $return ) ) {
 				global $wgLoopImprintLink;
-				#$out->redirect ( $wgLoopImprintLink );
+				$out->redirect ( $wgLoopImprintLink );
 			}
 			$out->addHTML($return);
 
@@ -311,6 +301,23 @@ class SpecialLoopImprint extends UnlistedSpecialPage {
 			global $wgLoopImprintLink;
 			$out->redirect ( $wgLoopImprintLink );
 		}
+	}
+
+	public static function renderLoopImprintSpecialPage () {
+
+		global $wgServerName, $wgLoopExternalImprintPrivacy, $wgLoopExternalImprintUrl;
+			
+		$url = $wgLoopExternalImprintUrl.'?loop=' . $wgServerName;
+		
+		$cha = curl_init();
+		curl_setopt($cha, CURLOPT_URL, ($url));
+		curl_setopt($cha, CURLOPT_ENCODING, "UTF-8" );
+		curl_setopt($cha, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($cha, CURLOPT_FOLLOWLOCATION, true);
+		$return = curl_exec( $cha );
+		curl_close( $cha );
+
+		return $return;
 	}
 }
 
@@ -332,21 +339,10 @@ class SpecialLoopPrivacy extends UnlistedSpecialPage {
 		$this->setHeaders();
 
 		if ( $wgLoopExternalImprintPrivacy && !empty ( $wgLoopExternalPrivacyUrl ) ) {
-
-			global $wgServerName;
-			
-			$url = $wgLoopExternalPrivacyUrl.'?loop=' . $wgServerName;
-			
-			$cha = curl_init();
-			curl_setopt($cha, CURLOPT_URL, ($url));
-			curl_setopt($cha, CURLOPT_ENCODING, "UTF-8" );
-			curl_setopt($cha, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($cha, CURLOPT_FOLLOWLOCATION, true);
-			$return = curl_exec($cha);
-			curl_close($cha);
+			$return = self::renderLoopPrivacySpecialPage();
 			if ( empty( $return ) ) {
-				global $wgLoopImprintLink;
-				$out->redirect ( $wgLoopImprintLink );
+				global $wgLoopPrivacyLink;
+				$out->redirect ( $wgLoopPrivacyLink );
 			}
 			$out->addHTML($return);
 
@@ -355,5 +351,22 @@ class SpecialLoopPrivacy extends UnlistedSpecialPage {
 			$out->redirect ( $wgLoopPrivacyLink );
 		}
 
+	}
+	
+	public static function renderLoopPrivacySpecialPage () {
+
+		global $wgServerName, $wgLoopExternalPrivacyUrl;
+			
+		$url = $wgLoopExternalPrivacyUrl.'?loop=' . $wgServerName;
+		
+		$cha = curl_init();
+		curl_setopt($cha, CURLOPT_URL, ($url));
+		curl_setopt($cha, CURLOPT_ENCODING, "UTF-8" );
+		curl_setopt($cha, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($cha, CURLOPT_FOLLOWLOCATION, true);
+		$return = curl_exec( $cha );
+		curl_close( $cha );
+
+		return $return;
 	}
 }

--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -22,6 +22,13 @@ abstract class LoopExport {
 
 
 	public function getExistingExportFile() {
+
+		global $wgRequest, $wgLoopExportDebug;
+		$debug = $wgRequest->getText("debug");
+		if ( $debug == "true" || $wgLoopExportDebug ) {
+			return false;
+		}
+
 		global $wgUploadDirectory;
 
 		$export_dir = $wgUploadDirectory.$this->exportDirectory.'/'.$this->structure->getId();
@@ -176,10 +183,6 @@ class LoopExportXml extends LoopExport {
 
 	}
 
-	// for Development
-	public function getExistingExportFile() {
-		return false;
-	}
 }
 
 
@@ -220,10 +223,6 @@ class LoopExportPdf extends LoopExport {
 
 	}
 
-	// for Development
-	public function getExistingExportFile() {
-		return false;
-	}
 }
 
 
@@ -293,7 +292,7 @@ class LoopExportPageMp3 extends LoopExport {
 
 	public function generateExportContent() {
 		$query = $this->request->getQueryValues();
-		set_time_limit(30);
+		set_time_limit(300);
 		if ( isset( $query['articleId'] ) ) {
 			if ( isset( $query['debug'] ) ) {
 				$this->exportContent = LoopMp3::getMp3FromRequest($this->structure, $query['articleId'], $query['debug'] );

--- a/includes/LoopExport.php
+++ b/includes/LoopExport.php
@@ -262,6 +262,8 @@ class LoopExportMp3 extends LoopExport {
 		header("Content-Type: application/zip");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 	
@@ -307,6 +309,8 @@ class LoopExportPageMp3 extends LoopExport {
 		header("Last-Modified: " . date("D, d M Y H:i:s T", strtotime($this->structure->lastChanged())));
 		header("Content-Type: text/html");
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 	
@@ -343,6 +347,8 @@ class LoopExportEpub extends LoopExport {
 		header("Content-Type: application/epub+zip");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 }
@@ -382,6 +388,8 @@ class LoopExportHtml extends LoopExport {
 		header("Content-Type: application/zip");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 
@@ -418,6 +426,8 @@ class LoopExportScorm extends LoopExport {
 		header("Content-Type: application/zip");
 		header('Content-Disposition: attachment; filename="' . $filename . '";' );
 		header("Content-Length: ". strlen($this->exportContent));
+		header("Cache-Control: max-age=0, no-cache, no-store, must-revalidate");
+		header("Expires: " . date("D, d M Y H:i:s T"));
 
 	}
 

--- a/includes/LoopHtml.php
+++ b/includes/LoopHtml.php
@@ -27,6 +27,8 @@ class LoopHtml{
 
     public static function structure2html(LoopStructure $loopStructure, RequestContext $context, $exportDirectory) {
 
+        set_time_limit(600);
+        
         $loopStructureItems = $loopStructure->getStructureItems();
 
         if(is_array($loopStructureItems)) {

--- a/includes/LoopHtml.php
+++ b/includes/LoopHtml.php
@@ -29,7 +29,7 @@ class LoopHtml{
 
     public static function structure2html(LoopStructure $loopStructure, RequestContext $context, $exportDirectory) {
 
-        set_time_limit(600);
+        set_time_limit(1800);
         
         $loopStructureItems = $loopStructure->getStructureItems();
 

--- a/includes/LoopHtml.php
+++ b/includes/LoopHtml.php
@@ -242,7 +242,7 @@ class LoopHtml{
      * 
      * @Return string html
      */   
-    private static function writeSpecialPageToFile( $specialPage, $prependHref, $exportSkin, $content = null ) {
+    private static function writeSpecialPageToFile( $specialPage, $prependHref, $exportSkin ) {
 
        # $loopStructure = new LoopStructure;
         #$loopStructure->loadStructureItems();
@@ -289,6 +289,7 @@ class LoopHtml{
                 $content = SpecialLoopTerminology::renderLoopTerminologySpecialPage();
                 break;
             default:
+                $content = '';
                 break;
         }
         

--- a/includes/LoopHtml.php
+++ b/includes/LoopHtml.php
@@ -24,6 +24,8 @@ class LoopHtml{
 
     private $requestedUrls = array();
     private $exportDirectory;
+    private $imprintHref; # needed on every page - requesting external imprint service for every page would be bad.
+    private $privacyHref;
 
     public static function structure2html(LoopStructure $loopStructure, RequestContext $context, $exportDirectory) {
 
@@ -40,9 +42,12 @@ class LoopHtml{
             $loopSettings->loadSettings();
 
             $exportHtmlDirectory = $wgUploadDirectory.$exportDirectory;
-            LoopHtml::getInstance()->startDirectory = $exportHtmlDirectory.'/'.$loopStructure->getId().'/';
-            LoopHtml::getInstance()->exportDirectory = $exportHtmlDirectory.'/'.$loopStructure->getId().'/files/';
-
+            $loopHtml = LoopHtml::getInstance();
+            $loopHtml->startDirectory = $exportHtmlDirectory.'/'.$loopStructure->getId().'/';
+            $loopHtml->exportDirectory = $exportHtmlDirectory.'/'.$loopStructure->getId().'/files/';
+            $loopHtml->imprintHref = LoopHtml::getImprintPrivacyLinks("imprint");
+            $loopHtml->privacyHref = LoopHtml::getImprintPrivacyLinks("privacy");
+            #dd(LoopHtml::getInstance());
             //$articlePath = preg_replace('/(\/)/', '\/', $wgArticlePath);
             //LoopHtml::getInstance()->articlePathRegEx = preg_replace('/(\$1)/', '', $articlePath);
 
@@ -89,7 +94,17 @@ class LoopHtml{
             foreach( $glossaryPages as $title ) {
                 LoopHtml::writeArticleToFile( $title, "", $exportSkin );
             }
-            if ( filter_var( htmlspecialchars_decode( $wgLoopImprintLink ), FILTER_VALIDATE_URL ) == false ) {
+            
+            global $wgLoopExternalImprintPrivacy, $wgLoopExternalImprintUrl, $wgLoopExternalPrivacyUrl;
+            $specialPageImprintContent = "";
+            if ( $wgLoopExternalImprintPrivacy && !empty ( $wgLoopExternalImprintUrl ) ) {
+                $specialPageImprintContent = SpecialLoopImprint::renderLoopImprintSpecialPage();
+                if ( !empty ( $specialPageImprintContent ) ) { 
+                    $imprintTitle = Title::newFromText( "LoopImprint", NS_SPECIAL );
+                    LoopHtml::writeSpecialPageToFile( $imprintTitle, "", $exportSkin, $specialPageImprintContent );
+                }
+            }
+            if ( $specialPageImprintContent == "" && filter_var( htmlspecialchars_decode( $wgLoopImprintLink ), FILTER_VALIDATE_URL ) == false ) {
                 $imprintTitle = Title::newFromText( $wgLoopImprintLink );
                 if ( ! empty ( $imprintTitle->mTextform ) ) {
                     $wikiPage = WikiPage::factory( $imprintTitle );
@@ -99,7 +114,17 @@ class LoopHtml{
                     }
                 }
             }
-            if ( filter_var( htmlspecialchars_decode( $wgLoopPrivacyLink ), FILTER_VALIDATE_URL ) == false ) {
+
+            $specialPagePrivacyContent = "";
+            if ( $wgLoopExternalImprintPrivacy && !empty ( $wgLoopExternalPrivacyUrl ) ) {
+                $specialPagePrivacyContent = SpecialLoopPrivacy::renderLoopPrivacySpecialPage();
+                if ( !empty ( $specialPagePrivacyContent ) ) { 
+                    $privacyTitle = Title::newFromText( "LoopPrivacy", NS_SPECIAL );
+                    LoopHtml::writeSpecialPageToFile( $privacyTitle, "", $exportSkin, $specialPagePrivacyContent );
+                }
+            }
+            
+            if ( $specialPagePrivacyContent == "" && filter_var( htmlspecialchars_decode( $wgLoopPrivacyLink ), FILTER_VALIDATE_URL ) == false ) {
                 $privacyTitle = Title::newFromText( $wgLoopPrivacyLink );
                 if ( ! empty ( $privacyTitle->mTextform ) ) {
                     $wikiPage = WikiPage::factory( $privacyTitle );
@@ -172,6 +197,43 @@ class LoopHtml{
         }
 
     }
+
+    private static function getImprintPrivacyLinks( $mode ) {
+
+		global $wgLoopExternalImprintPrivacy, $wgLoopExternalPrivacyUrl, $wgLoopExternalImprintUrl, $wgLoopImprintLink, $wgLoopPrivacyLink;
+        
+        if ( $mode == "imprint" ) {
+            $externalUrl = $wgLoopExternalImprintUrl;
+            $loopSettingsLink = $wgLoopImprintLink;
+        } else {
+            $externalUrl = $wgLoopExternalPrivacyUrl;
+            $loopSettingsLink = $wgLoopPrivacyLink;
+        }
+
+        if ( $wgLoopExternalImprintPrivacy && !empty ( $externalUrl ) ) {
+            if ( $mode == "imprint" ) {
+                if ( !empty( SpecialLoopImprint::renderLoopImprintSpecialPage() ) ) {
+                    $title = Title::newFromText( "LoopImprint", NS_SPECIAL );
+                    return wfMessage( strtolower( $title->mTextform ) )->text() . ".html";
+                }
+            } else {
+                if ( !empty( SpecialLoopPrivacy::renderLoopPrivacySpecialPage() ) ) {
+                    $title = Title::newFromText( "LoopPrivacy", NS_SPECIAL );
+                    return wfMessage( strtolower( $title->mTextform ) )->text() . ".html";
+                }
+            }
+        }
+        if ( filter_var( htmlspecialchars_decode( $loopSettingsLink ), FILTER_VALIDATE_URL ) ) {
+            # Given link is a URL to a webpage
+            return $loopSettingsLink;
+        } else {
+            # Link is a local page
+            $title = Title::newFromText( $loopSettingsLink );
+            return LoopHtml::getInstance()->resolveUrl( $title->mUrlform, '.html');
+        }
+            
+    }
+
      /**
      * Write Special Page to file, with all given resources
      * @param Title $specialPage
@@ -180,7 +242,7 @@ class LoopHtml{
      * 
      * @Return string html
      */   
-    private static function writeSpecialPageToFile( $specialPage, $prependHref, $exportSkin ) {
+    private static function writeSpecialPageToFile( $specialPage, $prependHref, $exportSkin, $content = null ) {
 
        # $loopStructure = new LoopStructure;
         #$loopStructure->loadStructureItems();
@@ -227,7 +289,7 @@ class LoopHtml{
                 $content = SpecialLoopTerminology::renderLoopTerminologySpecialPage();
                 break;
             default:
-                $content = '';
+                break;
         }
         
         $htmlFileName = LoopHtml::getInstance()->exportDirectory.$tmpFileName;
@@ -436,7 +498,12 @@ class LoopHtml{
                 "srcpath" => $skinPath."Loop/resources/js/h5presizer.js",
                 "targetpath" => "resources/js/",
                 "link" => "script-btm"
-            )
+            ),
+            "skins.featherlight.js" => array(
+                "srcpath" => $skinPath."Loop/node_modules/featherlight/release/featherlight.min.js",
+                "targetpath" => "resources/js/",
+                "link" => "script-btm"
+            ),
         );
 
         $skinStyle = str_replace( "style-", "loop-", $wgDefaultUserOptions["LoopSkinStyle"]);
@@ -551,10 +618,12 @@ class LoopHtml{
             
             if ( $internalLinks ) {
                 foreach ( $internalLinks as $element ) {
+                    
                     $tmpHref = $element->getAttribute( 'href' );
                     if ( isset ( $tmpHref ) && $tmpHref != '#' ) {
                         $element->setAttribute( 'href', $prependHref.$tmpHref );
                     }
+                    
                 }
             }
         }
@@ -652,11 +721,35 @@ class LoopHtml{
         $pdfLink = $doc->getElementByID( "loop-pdf-download" );
         if ( !empty( $pdfLink ) ) {
             $loopStructure = new LoopStructure();
+            $loopStructure->loadStructureItems();
             $exportPdf = new LoopExportPdf( $loopStructure );
             $fileLink = $prependHref . "resources/pdf/" . $exportPdf->getExportFilename();
             $pdfLink->setAttribute( "href", $fileLink );
         }
+
+        $mp3Link = $doc->getElementByID( "loop-mp3-download" );
+        if ( !empty( $mp3Link ) ) {
+            $loopStructure = new LoopStructure();
+            $loopStructure->loadStructureItems();
+            $exportMp3 = new LoopExportMp3( $loopStructure );
+            $fileLink = $prependHref . "resources/mp3/" . $exportMp3->getExportFilename();
+            $mp3Link->setAttribute( "href", $fileLink );
+        }
         
+        $imprintLink = $doc->getElementByID( "imprintlink" );
+        if ( filter_var( htmlspecialchars_decode( $this->imprintHref ), FILTER_VALIDATE_URL ) ) {
+            $imprintLink->setAttribute( "href", $this->imprintHref );
+        } else {
+            $imprintLink->setAttribute( "href", $prependHref.$this->imprintHref );
+        }
+        
+        $privacyLink = $doc->getElementByID( "privacylink" );
+        if ( filter_var( htmlspecialchars_decode( $this->privacyHref ), FILTER_VALIDATE_URL ) ) {
+            $privacyLink->setAttribute( "href", $this->privacyHref );
+        } else {
+            $privacyLink->setAttribute( "href", $prependHref.$this->privacyHref );
+        }
+
         $html = $doc->saveHtml();
         return $html;
     }

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -33,9 +33,9 @@ class LoopPdf {
 		if ( !empty($xmlfo["errors"]) ) {
 			var_dump($xmlfo["errors"]);
 		}
-		if ( strpos( $pdf, "%PDF") !== 0 ) {
-			#es werden keine leeren/fehlerhaften PDFs mehr heruntergeladen, solange das hier aktiv ist.
-			var_dump( "Error! Anstatt eine leere PDF auszugeben, gibt es jetzt den content hier. #debug", $pdf, $xmlfo, $wiki_xml );exit; #dd ist zu JS-ressourcenintensiv
+		
+		if ( strpos( $pdf, "%PDF") !== 0 ) { # error!
+			return [$pdf, $xmlfo, $wiki_xml];
 		}
 		#var_dump( "Debug! PDF funktioniert eigentlich. ", $xmlfo, $wiki_xml );exit;
 		return $pdf;

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -22,7 +22,7 @@ class LoopPdf {
 	public static function structure2pdf(LoopStructure $structure, $modifiers = null) {
 		global $IP;
 		
-		set_time_limit(300);
+		set_time_limit(1200);
 
 		$wiki_xml = LoopXml::structure2xml($structure);
 		$errors = '';

--- a/includes/LoopPdf.php
+++ b/includes/LoopPdf.php
@@ -167,8 +167,9 @@ class SpecialLoopExportPdfTest extends SpecialPage {
 						);
 
 					$html .= "<br><br>";
-					$html .= "<nowiki>". $tmpPdf . "</nowiki><br>";
-					$html .= $xmlfo["errors"] . "<br>";
+
+					$html .= "<pre>". implode("\n", array_slice(explode("\n", $tmpPdf), 1)) . "</pre><br>";
+					$html .= $xmlfo["errors"];
 					$error = $item->tocText;
 					break;
 				}

--- a/includes/LoopSettings.php
+++ b/includes/LoopSettings.php
@@ -697,10 +697,9 @@ class SpecialLoopSettings extends SpecialPage {
 					### LINK BLOCK ###
                     $html .= '<h3>' . $this->msg( 'loopsettings-headline-footer-links' ) . '</h3>';
                     
-
-                    global $wgLoopExternalImprintPrivacy, $wgLoopExternalPrivacyUrl;
+                    global $wgLoopExternalImprintPrivacy;
                     
-                    if ( ! $wgLoopExternalImprintPrivacy || empty ( $wgLoopExternalPrivacyUrl ) ) {
+                    if ( ! $wgLoopExternalImprintPrivacy ) {
                         $html .= '<div class="form-row mb-4">';
 
                         # imprint link

--- a/includes/LoopSettings.php
+++ b/includes/LoopSettings.php
@@ -277,7 +277,7 @@ class LoopSettings {
 
     public function getLoopSettingsFromRequest ( $request, $user ) {
         
-        global $wgLoopSocialIcons, $wgLoopSkinStyles, $wgAvailableLicenses, $wgLegalTitleChars;
+        global $wgLoopSocialIcons, $wgLoopAvailableSkinStyles, $wgAvailableLicenses, $wgLegalTitleChars;
         $this->errors = array();
         $this->rightsText = $request->getText( 'rights-text' ); # no validation required
         
@@ -337,7 +337,7 @@ class LoopSettings {
             array_push( $this->errors, wfMessage( 'loopsettings-error' )  . ': ' . wfMessage( 'loopsettings-use-cc-label' ) );
         }
         
-        if ( in_array( $request->getText( 'skin-style' ), $wgLoopSkinStyles ) ) {
+        if ( in_array( $request->getText( 'skin-style' ), $wgLoopAvailableSkinStyles ) ) {
             $this->skinStyle = $request->getText( 'skin-style' );
             $user->setOption( 'LoopSkinStyle', $this->skinStyle );
 			$user->saveSettings();

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -166,17 +166,18 @@ class LoopXml {
 					if ( ! in_array( $node->getAttribute("id"), $idCache ) )  {
 						$idCache[] = $node->getAttribute("id");
 					} else {
-						$idCache[] = $node->getAttribute("id");
 						$node->removeAttribute("id");
 					}
 				} 
 			}
 		}
 		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $dom->saveXML());
+		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\\?\>\n)/", "", $dom->saveXML());
 
 		if ( empty( $newContentText ) ) {
 			echo "<script>console.log('Articles XML Invalid');</script>"; # when the given XML is invalid, no domdocument doesn't load it. this is a hidden error message
 			return false;
+			$contentText = $newContentText;
 		} elseif ( $contentText != $newContentText ) {
 			$contentText = $newContentText;
 		}

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -115,7 +115,10 @@ class LoopXml {
 		#dd();
 
 		# modify content for resolving space issues with syntaxhighlight in pdf
-		$content = preg_replace('/(<syntaxhighlight.*)(>)(.*)(<\/syntaxhighlight>)/U', "$1$2$3\n$4", $content);
+		$content = preg_replace('/(<syntaxhighlight.*)(>)(.*)(<\/syntaxhighlight>)/iU', "$1$2$3\n$4", $content);
+
+		# remove html comments - these cause the whole page to vanish from XML and PDF
+		$content = preg_replace('/(<!--.*-->)/iU', "", $content);
 		
 		# modify content for mp3 export
 		if ( $modifiers["mp3"] ) {

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -166,14 +166,18 @@ class LoopXml {
 					if ( ! in_array( $node->getAttribute("id"), $idCache ) )  {
 						$idCache[] = $node->getAttribute("id");
 					} else {
+						$idCache[] = $node->getAttribute("id");
 						$node->removeAttribute("id");
 					}
 				} 
 			}
 		}
-		$newContentText = substr( $dom->saveXML(), 22, -1);
-		
-		if ( $contentText != $newContentText ) {
+		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $dom->saveXML());
+
+		if ( empty( $newContentText ) ) {
+			echo "<script>console.log('Articles XML Invalid');</script>"; # when the given XML is invalid, no domdocument doesn't load it. this is a hidden error message
+			return false;
+		} elseif ( $contentText != $newContentText ) {
 			$contentText = $newContentText;
 		}
 		

--- a/includes/LoopXml.php
+++ b/includes/LoopXml.php
@@ -172,7 +172,7 @@ class LoopXml {
 			}
 		}
 		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\ encoding=\"utf-8\"\?\>\n)/", "", $dom->saveXML());
-		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\\?\>\n)/", "", $dom->saveXML());
+		$newContentText = preg_replace("/^(\<\?xml version=\"1.0\"\\?\>\n)/", "", $newContentText);
 
 		if ( empty( $newContentText ) ) {
 			echo "<script>console.log('Articles XML Invalid');</script>"; # when the given XML is invalid, no domdocument doesn't load it. this is a hidden error message


### PR DESCRIPTION
**Exporte Allgemein**
- Neu: Export-Debug mode mit ?debug=true oder $wgLoopExportDebug = true 
- Kein Export wird mehr im Browser gecached.
- Alle Exporte werden jetzt gespeichert und nicht mehr für die Entwicklung immer neu generiert

**PDF**
- HTML-Kommentare sind jetzt kein Problem mehr für XML und PDF.
- PDF: gerenderte Fehlermeldung, wenn die PDF nicht funktioniert. Als Admin sieht man den kompletten Fehlerbericht. Hat man die Rechte, seitenweise zu testen, wird ein Link zum Test bereitgestellt. Sonst ein Link zum Fehler melden, sofern verfügbar.

**Offlineversion**
- HTML Export fixes - diverse Links korrigiert; time Limit
- HTML Export unterstützt jetzt die Impressums-Special page

**Sonstiges**
- LoopSettings Variable Name fixed