### PR TITLE
PDF fix, Spoiler/Math fix

### DIFF
--- a/includes/Loop.hooks.php
+++ b/includes/Loop.hooks.php
@@ -70,7 +70,7 @@ class LoopHooks {
 		$hideSpecialPages = false;
 		if ( $user->mId == null ) { # no check for specific rights - anon users get blocked from viewing these special pages.
 			$hideSpecialPages = true;
-		} elseif ( in_array( "shared", $user->getGroups() ) ) {
+		} elseif ( in_array( "shared", $user->getGroups() ) || in_array( "shared_basic", $user->getGroups() ) ) {
 			$hideSpecialPages = true;
 			$hideExtended = array( 'ChangeCredentials', 'ChangeEmail', "PasswordReset", "Preferences" );
 		} elseif ( ! $user->isAllowed( "loop-view-special-pages" ) ) { # for logged in users, we can check the rights.

--- a/includes/LoopFeedback.php
+++ b/includes/LoopFeedback.php
@@ -23,7 +23,7 @@ class LoopFeedback {
 		
 		$title = $wgOut->getTitle();
 		$user = $wgOut->getUser();
-		if ( !$user->isAllowed( 'loopfeedback-view' ) || in_array( "shared", $user->getGroups() ) ) {
+		if ( !$user->isAllowed( 'loopfeedback-view' ) || in_array( "shared", $user->getGroups() ) || in_array( "shared_basic", $user->getGroups() ) ) {
 			return false;
 		}
 		

--- a/includes/LoopLiterature.php
+++ b/includes/LoopLiterature.php
@@ -898,7 +898,7 @@ class LoopLiterature {
 		# Author/''Title''. (editor). (year). Series. ''Title'' (Type)(Volume). Publisher/Institution/school
 		if ( $li->author ) {
 			if ( $type == 'xml' ) {
-				$return .= '<bold>' . $li->author."<bold> ";
+				$return .= '<bold>' . $li->author."</bold> ";
 			} else {
 				$return .= $li->author." ";
 			}

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -202,43 +202,49 @@ class LoopObject {
 			$html .= $this->error;
 		} 
 	
-		$html .= '<div class="loop_object_content">';
+		$content = '<div class="loop_object_content">';
 
-		$html .= $this->getContent();
+		$content .= $this->getContent();
 		
-		$html .= '</div>';
-			
+		$content .= '</div>';
+
+		$footer = '';
 		if ( $this->getRenderOption() != 'none' ) {
-			$html .= '<div class="loop_object_footer">';
-			$html .= '<div class="loop_object_title">';
+			$footer .= '<div class="loop_object_footer">';
+			$footer .= '<div class="loop_object_title">';
 			if ($this->getRenderOption() == 'icon') {
-				$html .= '<span class="loop_object_icon"><span class="ic ic-'.$this->getIcon().'"></span>&nbsp;</span>';
+				$footer .= '<span class="loop_object_icon"><span class="ic ic-'.$this->getIcon().'"></span>&nbsp;</span>';
 			}
 			if (($this->getRenderOption() == 'icon') || ($this->getRenderOption() == 'marked')) {
-				$html .= '<span class="loop_object_name">'.wfMessage ( $this->getTag().'-name-short' )->inContentLanguage ()->text () . '</span>';
+				$footer .= '<span class="loop_object_name">'.wfMessage ( $this->getTag().'-name-short' )->inContentLanguage ()->text () . '</span>';
 			}
 			if ( $showNumbering && (($this->getRenderOption() == 'icon') || ($this->getRenderOption() == 'marked')) && $this->mIndexing ) {
-				$html .= '<span class="loop_object_number"> '.LOOPOBJECTNUMBER_MARKER_PREFIX . $this->getTag() . $this->getId() . LOOPOBJECTNUMBER_MARKER_SUFFIX;
-				$html .= '</span>';
+				$footer .= '<span class="loop_object_number"> '.LOOPOBJECTNUMBER_MARKER_PREFIX . $this->getTag() . $this->getId() . LOOPOBJECTNUMBER_MARKER_SUFFIX;
+				$footer .= '</span>';
 			}
 			if (($this->getRenderOption() == 'icon') || ($this->getRenderOption() == 'marked')) {
-				$html .= '<span class="loop_object_title_seperator">:&nbsp;</span><wbr>';
+				$footer .= '<span class="loop_object_title_seperator">:&nbsp;</span><wbr>';
 			}
 			if ($this->getRenderOption() != 'none' && $this->getTitle()) {
-				$html .= '<span class="loop_object_title_content">'.$this->getTitle().'</span>';
+				$footer .= '<span class="loop_object_title_content">'.$this->getTitle().'</span>';
 			}
-			$html .= '</div>';
+			$footer .= '</div>';
 				
 			if ($this->getDescription()  && (($this->getRenderOption() == 'icon') || ($this->getRenderOption() == 'marked'))) {
-				$html .= '<div class="loop_object_description">' . $this->getDescription() . '</div>';
+				$footer .= '<div class="loop_object_description">' . $this->getDescription() . '</div>';
 			} 
 			if ($this->getCopyright()  && (($this->getRenderOption() == 'icon') || ($this->getRenderOption() == 'marked'))) {
-				$html .= '<div class="loop_object_copyright">' . $this->getCopyright() . '</div>';
+				$footer .= '<div class="loop_object_copyright">' . $this->getCopyright() . '</div>';
 			}
 	
-			$html .= '</div>';
+			$footer .= '</div>';
 		}
-			
+		
+		if ( $this->getTag() == "loop_task" ) {
+			$html .= $footer . $content;
+		} else {
+			$html .= $content . $footer;
+		}
 		$html .= '</div>';
 	
 		return $html;

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -312,7 +312,9 @@ class LoopObject {
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 		$linkRenderer->setForceArticlePath(true);
 		if ( $lsi ) {
-			$linktext = $lsi->tocNumber . ' ' . $lsi->tocText;
+			global $wgLoopLegacyPageNumbering;
+
+			$linktext = $wgLoopLegacyPageNumbering ? $lsi->tocNumber . ' ' . $lsi->tocText : $lsi->tocText;
 			
 			$html .= $linkRenderer->makeLink( 
 				$linkTitle, 

--- a/includes/LoopObject.php
+++ b/includes/LoopObject.php
@@ -865,22 +865,22 @@ class LoopObject {
 									$tmpLoopObjectIndex->itemType = $object[2]["type"];
 								}
 								if ( isset( $object[2]["title"] ) ) {
-									$tmpLoopObjectIndex->itemTitle = $object[2]["title"];
+									$tmpLoopObjectIndex->itemTitle = htmlspecialchars( $object[2]["title"] );
 								} else {
 									$title_tags = array ();
 									$parser->extractTagsAndParams( ["loop_title", "loop_figure_title"], $object[1], $title_tags );
 									foreach( $title_tags as $tag ) {
-										$tmpLoopObjectIndex->itemTitle = $tag[1];
+										$tmpLoopObjectIndex->itemTitle = htmlspecialchars( $tag[1] );
 										break;
 									}
 								}
 								if ( isset( $object[2]["description"] ) ) {
-									$tmpLoopObjectIndex->itemDescription = $object[2]["description"];
+									$tmpLoopObjectIndex->itemDescription = htmlspecialchars(  $object[2]["description"] );
 								} else {
 									$desc_tags = array ();
 									$parser->extractTagsAndParams( ["loop_description", "loop_figure_description"], $object[1], $desc_tags );
 									foreach( $desc_tags as $tag ) {
-										$tmpLoopObjectIndex->itemDescription = $tag[1];
+										$tmpLoopObjectIndex->itemDescription =  htmlspecialchars( $tag[1] );
 										break;
 									}
 								}
@@ -895,6 +895,7 @@ class LoopObject {
 								} else {
 									$valid = false;
 								}
+								
 								if ( $valid && $stable && ( ! isset ( $object[2]["index"] ) || strtolower($object[2]["index"]) != "false" ) && ( ! isset ( $object[2]["render"] ) || strtolower($object[2]["render"]) != "none" ) ) {
 									$tmpLoopObjectIndex->addToDatabase();
 								}

--- a/includes/LoopSpoiler.php
+++ b/includes/LoopSpoiler.php
@@ -92,7 +92,7 @@ class LoopSpoiler {
 			$content = substr( $content, 0, -1 );
 		}
 		# replace math uniq markers
-		$content = preg_replace('/(\'"`UNIQ--postMath-\d{8}-QINU`"\')/', '<span class="loopspoiler_math_replace"></span>', $content);
+		$content = preg_replace('/(\'"`UNIQ--postMath-\w{8}-QINU`"\')/', '<span class="loopspoiler_math_replace"></span>', $content);
 		
 		return Html::rawElement(
 			'button',

--- a/includes/LoopSpoiler.php
+++ b/includes/LoopSpoiler.php
@@ -65,14 +65,24 @@ class LoopSpoiler {
 		$parser->getOutput()->addModules( 'loop.spoiler.js' );
 		
 		$spoiler = LoopSpoiler::newFromTag( $input, $args, $parser, $frame );
-		$spoiler->setContent( $parser->recursiveTagParseFully( $input ), $frame );
-		$return = "";
+		
+		$span = "";
+		$parser->extractTagsAndParams( ["math"], $input, $math_tags );
+		foreach ( $math_tags as $i => $math ) {
+			$span .=  $parser->recursiveTagParseFully( "<math>".$math[1]."</math>", $frame );
+		}
+		$span = str_replace("<p>", "", $span);
+		$span = str_replace("</p>", "", $span);
+		$spoiler->btnAppend = $span;
 
+		$spoiler->setContent( $parser->recursiveTagParseFully( $input, $frame ) );
+		
+		$return = "";
 		if ( !empty ( $spoiler->mErrors ) ) {
 			$return .= "$spoiler->mErrors";
 		}
 		$return .= $spoiler->render();
-		
+
 		return $return;
 	}
 	
@@ -81,12 +91,14 @@ class LoopSpoiler {
 		while ( substr( $content, -1, 2 ) == "\n" ) { # remove newlines at the end of content for cleaner html output
 			$content = substr( $content, 0, -1 );
 		}
+		# replace math uniq markers
+		$content = preg_replace('/(\'"`UNIQ--postMath-\d{8}-QINU`"\')/', '<span class="loopspoiler_math_replace"></span>', $content);
 		
 		return Html::rawElement(
 			'button',
-			[ 'data-spoilercontent' => $content,'type' => 'button', 'class' => 'btn loopspoiler loopspoiler_type_' . $this->getType() . ' ' . $this->getId(),],
-			$this->getBtnText()
-		);
+			[ 'data-spoilercontent' => $content,'type' => 'button', 'id' => $this->getId(), 'class' => 'btn loopspoiler loopspoiler_type_' . $this->getType() . ' ' . $this->getId(),],
+			$this->getBtnText() . $this->btnAppend 
+		) ;
 	}
 
 	public static function newFromTag( $input, array $args, Parser $parser, PPFrame $frame ) {
@@ -118,7 +130,8 @@ class LoopSpoiler {
 			$spoiler->setBtnText( wfMessage( 'loopspoiler-default-title' )->inContentLanguage()->text() );
 		} else {
 			$spoiler->setBtnText( htmlspecialchars( $args['text'] ) ); // parser raus
-		}		
+		}
+
 		
 		return $spoiler;
 	}

--- a/includes/LoopWikiEditor.php
+++ b/includes/LoopWikiEditor.php
@@ -26,11 +26,10 @@ class LoopWikiEditor {
         $objects = LoopObjectIndex::getAllObjects ( $loopStructure );
         $output = array();
         foreach ( $objects as $refid => $data) {
-            $output[$data["index"]][$data["objectnumber"] ."::". $data["id"] ] = wfMessage($data["index"]."-name-short")->text() . " " . $data["objectnumber"];
-            $output[$data["index"]][$data["objectnumber"] ."::". $data["id"] ] .= ( isset( $data["title"] ) ) ? ": " . $data["title"] : "";
-            ksort( $output[$data["index"]], SORT_NUMERIC );
+            $output[$data["index"]][( empty( $data["objectnumber"] ) ? "999999" : $data["objectnumber"] ) ."::". $data["id"] ] = wfMessage($data["index"]."-name-short")->text() . ( !empty( $data["objectnumber"] ) ? " " . $data["objectnumber"] : "" );
+            $output[$data["index"]][( empty( $data["objectnumber"] ) ? "999999" : $data["objectnumber"] ) ."::". $data["id"] ] .= ( isset( $data["title"] ) ) ? ": " . html_entity_decode ( $data["title"] ) : "";
+            ksort( $output[$data["index"]], SORT_NUMERIC ); # put items without object number to the end of the list
         }
-
         $script = "var loop_elements = {\n";
         
         foreach ( $output as $index => $data ) {

--- a/resources/js/loop.spoiler.js
+++ b/resources/js/loop.spoiler.js
@@ -5,22 +5,28 @@
 
 $('.loopspoiler').click(function() {
   
-  if($('.loopspoiler_default_content').length) {
-    $('.loopspoiler_default_content').remove();
-    return 0;
-  } else if($('.loopspoiler_transparent_content').length) {
-    $('.loopspoiler_transparent_content').remove();
-    return 0;
-  }
-
-  let content = $(this).attr('data-spoilercontent');
-
-  if($(this).hasClass('loopspoiler_type_transparent')) {
-    type = 'transparent';
+  if ($(this).attr("data-loaded") == "true") {
+    if($('.loopspoiler_default_content').length) {
+      $('.loopspoiler_default_content').toggle();
+    } else if($('.loopspoiler_transparent_content').length) {
+      $('.loopspoiler_transparent_content').toggle();
+    }
   } else {
-    type = 'default';
+    let content = $(this).attr('data-spoilercontent');
+
+    if($(this).hasClass('loopspoiler_type_transparent')) {
+      type = 'transparent';
+    } else {
+      type = 'default';
+    }
+    
+    $('#' + $(this).attr("id") +  " .mwe-math-element").each(function() {
+      content = content.replace('<span class="loopspoiler_math_replace"></span>', $(this).html() );
+      $(this).remove();
+    })
+    $('#' + $(this).attr("id")).attr("data-loaded", true);
+    $(this).after('<div class="loopspoiler_' + type + '_content">' + content + '</div>')
+  
   }
-
-  $(this).after('<div class="loopspoiler_' + type + '_content">' + content + '</div>')
-
+  
 });

--- a/resources/js/loop.spoiler.js
+++ b/resources/js/loop.spoiler.js
@@ -4,12 +4,13 @@
   */
 
 $('.loopspoiler').click(function() {
-  
+  let id = $(this).attr("id");
+
   if ($(this).attr("data-loaded") == "true") {
-    if($('.loopspoiler_default_content').length) {
-      $('.loopspoiler_default_content').toggle();
-    } else if($('.loopspoiler_transparent_content').length) {
-      $('.loopspoiler_transparent_content').toggle();
+    if($('.loopspoiler_default_content.'+id).length) {
+      $('.loopspoiler_default_content.'+id).toggle();
+    } else if($('.loopspoiler_transparent_content.'+id).length) {
+      $('.loopspoiler_transparent_content.'+id).toggle();
     }
   } else {
     let content = $(this).attr('data-spoilercontent');
@@ -25,7 +26,7 @@ $('.loopspoiler').click(function() {
       $(this).remove();
     })
     $('#' + $(this).attr("id")).attr("data-loaded", true);
-    $(this).after('<div class="loopspoiler_' + type + '_content">' + content + '</div>')
+    $(this).after('<div class="loopspoiler_' + type + '_content ' + id + '">' + content + '</div>')
   
   }
   

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -655,7 +655,7 @@
 				<xsl:if test="ancestor::extension[@extension_name='loop_area']">
 					<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
 				</xsl:if>
-				<fo:table keep-together.within-page="always" table-layout="fixed" content-width="150mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse" padding-start="0pt" padding-end="0pt" padding-top="4mm" padding-bottom="4mm"  padding-right="0pt">
+				<fo:table keep-together.within-page="auto" table-layout="fixed" content-width="150mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse" padding-start="0pt" padding-end="0pt" padding-top="4mm" padding-bottom="4mm"  padding-right="0pt">
 					<!-- <xsl:attribute name="id"><xsl:text>object</xsl:text><xsl:value-of select="@id"></xsl:value-of></xsl:attribute> -->
 					<fo:table-column column-number="1" column-width="0.4mm"/>
 					<fo:table-column column-number="2">
@@ -664,7 +664,10 @@
 								<xsl:attribute name="column-width">145mm</xsl:attribute>
 							</xsl:when>
 							<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
-								<xsl:attribute name="column-width">145mm</xsl:attribute>
+								<xsl:attribute name="column-width">140mm</xsl:attribute>
+							</xsl:when>
+							<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+								<xsl:attribute name="column-width">140mm</xsl:attribute>
 							</xsl:when>
 							<xsl:when test="ancestor::table">
 							
@@ -681,8 +684,11 @@
 									<xsl:when test="ancestor::extension[@extension_name='loop_area']">
 										<xsl:attribute name="max-width">145mm</xsl:attribute>
 									</xsl:when>
+									<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+										<xsl:attribute name="max-width">140mm</xsl:attribute>
+									</xsl:when>
 									<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
-										<xsl:attribute name="max-width">145mm</xsl:attribute>
+										<xsl:attribute name="max-width">140mm</xsl:attribute>
 									</xsl:when>
 									<xsl:otherwise>
 										<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
@@ -691,6 +697,9 @@
 								<fo:block text-align="left" margin-bottom="1mm">
 									<xsl:choose> 
 										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+											<xsl:attribute name="margin-left">0mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
 											<xsl:attribute name="margin-left">0mm</xsl:attribute>
 										</xsl:when>
 										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
@@ -717,17 +726,17 @@
 										<xsl:attribute name="padding-left">1mm</xsl:attribute>
 									</xsl:otherwise>
 								</xsl:choose> 
-									<xsl:if test="ancestor::extension[@extension_name='spoiler']">
-										<xsl:attribute name="padding-left">2mm</xsl:attribute>
-									</xsl:if>
 									<xsl:call-template name="font_object_title"></xsl:call-template>
 									<fo:block text-align="left">
 									<xsl:choose> 
-										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
-											<xsl:attribute name="margin-left">1mm</xsl:attribute>
+										<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
+											<xsl:attribute name="margin-left">0mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+											<xsl:attribute name="margin-left">0mm</xsl:attribute>
 										</xsl:when>
 										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
-											<xsl:attribute name="margin-left">13mm</xsl:attribute>
+											<xsl:attribute name="margin-left">13.5mm</xsl:attribute>
 										</xsl:when>
 										<xsl:otherwise>
 											<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
@@ -1161,17 +1170,15 @@
 									
 							<fo:inline>	
 								<xsl:choose>
+									<xsl:when test="@title">
+										<xsl:value-of select="@title"></xsl:value-of>
+									</xsl:when>
+									<xsl:when test="descendant::extension[@extension_name='loop_title']">
+										<xsl:apply-templates select="descendant::extension[@extension_name='loop_title']"  mode="loop_object"></xsl:apply-templates>
+									</xsl:when>
 									<xsl:when test="descendant::extension[@extension_name='loop_figure_title']">
 										<xsl:apply-templates select="descendant::extension[@extension_name='loop_figure_title']" mode="loop_object"></xsl:apply-templates>
 									</xsl:when>
-									<xsl:when test="descendant::extension[@extension_name='loop_title']">
-										<xsl:apply-templates select="descendant::extension[@extension_name='loop_title']"></xsl:apply-templates>
-									</xsl:when>
-									<xsl:otherwise>
-										<xsl:if test="@title">
-											<xsl:value-of select="@title"></xsl:value-of>
-										</xsl:if>
-									</xsl:otherwise>
 								</xsl:choose>	
 								<fo:leader leader-pattern="dots"></fo:leader>
 								<fo:page-number-citation>
@@ -1743,45 +1750,52 @@
 	
 	<!-- Loop Spoiler -->
 	<xsl:template name="spoiler">
-		<fo:block keep-together.within-page="auto">
-			<fo:block font-weight="bold" width="145mm">
-				<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1.3mm" padding-right="1.3mm" padding-top="1.3mm" padding-bottom="1.5mm">
+	<xsl:choose>
+		<xsl:when test="not(@noprint='true')">
+			<fo:block keep-together.within-page="auto">
+				<fo:block font-weight="bold" width="145mm">
+					<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1.3mm" padding-right="1.3mm" padding-top="1.3mm" padding-bottom="1.5mm">
 
-					<xsl:attribute name="background-color"><xsl:value-of select="$accent_color"></xsl:value-of></xsl:attribute>
-					<xsl:attribute name="color">#ffffff</xsl:attribute>					
-					<xsl:choose>
-						<xsl:when test="./descendant::extension[@extension_name='loop_spoiler_text']">
-							<xsl:apply-templates select="./descendant::extension[@extension_name='loop_spoiler_text']"></xsl:apply-templates>
-						</xsl:when>
-						<xsl:when test="@text">
-							<xsl:value-of select="@text"></xsl:value-of>
-						</xsl:when>
-						<xsl:otherwise>
-								<xsl:value-of select="$word_spoiler_defaulttitle"></xsl:value-of>
-						</xsl:otherwise>
-					</xsl:choose>
-				</fo:inline>			
-		</fo:block>
-		<fo:table keep-together.within-column="always" width="150mm" table-layout="fixed" border-collapse="separate" border-style="solid" border-width="0.3mm" border-color="{$accent_color}">
-			<fo:table-body>
-				<fo:table-row>
-					<fo:table-cell width="140mm">
-						<xsl:attribute name="padding-top">2mm</xsl:attribute>
-						<xsl:attribute name="padding-left">3mm</xsl:attribute>
-						<xsl:attribute name="padding-right">3mm</xsl:attribute>
-						<xsl:attribute name="padding-end">3mm</xsl:attribute>
-	
-						<fo:block>
-							<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-								<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
-							</xsl:if>
-							<xsl:apply-templates></xsl:apply-templates>
-						</fo:block>
-					</fo:table-cell>
-				</fo:table-row>
-			</fo:table-body>
-		</fo:table>
-		</fo:block>
+						<xsl:attribute name="background-color"><xsl:value-of select="$accent_color"></xsl:value-of></xsl:attribute>
+						<xsl:attribute name="color">#ffffff</xsl:attribute>					
+						<xsl:choose>
+							<xsl:when test="./descendant::extension[@extension_name='loop_spoiler_text']">
+								<xsl:apply-templates select="./descendant::extension[@extension_name='loop_spoiler_text']"></xsl:apply-templates>
+							</xsl:when>
+							<xsl:when test="@text">
+								<xsl:value-of select="@text"></xsl:value-of>
+							</xsl:when>
+							<xsl:otherwise>
+									<xsl:value-of select="$word_spoiler_defaulttitle"></xsl:value-of>
+							</xsl:otherwise>
+						</xsl:choose>
+					</fo:inline>			
+			</fo:block>
+			<fo:table keep-together.within-column="always" width="150mm" table-layout="fixed" border-collapse="separate" border-style="solid" border-width="0.3mm" border-color="{$accent_color}">
+				<fo:table-body>
+					<fo:table-row>
+						<fo:table-cell width="140mm">
+							<xsl:attribute name="padding-top">2mm</xsl:attribute>
+							<xsl:attribute name="padding-left">3mm</xsl:attribute>
+							<xsl:attribute name="padding-right">3mm</xsl:attribute>
+							<xsl:attribute name="padding-end">3mm</xsl:attribute>
+		
+							<fo:block>
+								<xsl:if test="ancestor::extension[@extension_name='loop_area']">
+									<!--<xsl:attribute name="margin-left">12.5mm</xsl:attribute> -->
+								</xsl:if>
+								<xsl:apply-templates></xsl:apply-templates>
+							</fo:block>
+						</fo:table-cell>
+					</fo:table-row>
+				</fo:table-body>
+			</fo:table>
+			</fo:block>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:call-template name="noprint_id_handling"></xsl:call-template>
+		</xsl:otherwise>
+	</xsl:choose>
 	</xsl:template>
 	
 	<!-- Loop Sidenote-->
@@ -1858,6 +1872,11 @@
 
 	<!-- Loop NoPrint-->
 	<xsl:template match="extension[@extension_name='loop_noprint']">
+		<xsl:call-template name="noprint_id_handling"></xsl:call-template>
+	</xsl:template>
+
+	<!-- General Handling of possible referenced objects that are in not-rendered tags -->
+	<xsl:template name="noprint_id_handling">
 		<fo:block></fo:block>
 		<xsl:choose>
 			<xsl:when test="./descendant::extension[@extension_name='loop_table']"><fo:block>
@@ -3024,7 +3043,11 @@
 		<xsl:variable name="loopobject">
 			<xsl:choose>
 				<xsl:when test="ancestor::extension[@extension_name='loop_figure']">true</xsl:when>	
-				<xsl:when test="ancestor::extension[@extension_name='loop_table']">true</xsl:when>		
+				<xsl:when test="ancestor::extension[@extension_name='loop_table']">true</xsl:when>	
+				<xsl:when test="ancestor::extension[@extension_name='loop_listing']">true</xsl:when>	
+				<xsl:when test="ancestor::extension[@extension_name='loop_formula']">true</xsl:when>	
+				<xsl:when test="ancestor::extension[@extension_name='loop_media']">true</xsl:when>		
+				<xsl:when test="ancestor::extension[@extension_name='loop_task']">true</xsl:when>		
 				<xsl:otherwise>false</xsl:otherwise>	
 			</xsl:choose>
 		</xsl:variable>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1631,6 +1631,21 @@
 	<xsl:template match="xhtml:sup">
 		<fo:inline vertical-align="super" font-size="0.8em"><xsl:apply-templates></xsl:apply-templates></fo:inline>
 	</xsl:template>	
+
+	<xsl:template match="xhtml:span|span" >
+		<fo:inline>
+			<xsl:call-template name="css-style-attributes"></xsl:call-template>
+			<xsl:apply-templates></xsl:apply-templates>
+		</fo:inline>
+	</xsl:template>
+	
+	<xsl:template match="xhtml:div|div" >
+		<fo:block>
+			<xsl:call-template name="css-style-attributes"></xsl:call-template>
+			<xsl:apply-templates></xsl:apply-templates>
+		</fo:block>
+	</xsl:template>	
+	
 	
 	<xsl:template match="big">
 		<fo:inline>
@@ -3318,8 +3333,8 @@
 	  </xsl:choose>
 	</xsl:template>	
 
+	<!-- loop_screenshot -->
 	<xsl:template match="extension[@extension_name='loop_screenshot']">
-		
 		<xsl:variable name="page" select="ancestor::article/@id"/>
 		<xsl:variable name="id" select="@id"/>
 		<xsl:variable name="img" select="php:function('LoopXsl::xsl_fetch_screenshot', $id, $page)"/>
@@ -3330,5 +3345,10 @@
 			</fo:external-graphic>
 		</xsl:if>
     </xsl:template>	
+	
+	<!-- loop_zoom -->
+	<xsl:template match="extension[@extension_name='loop_zoom']">
+		<xsl:apply-templates/>	
+	</xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1841,14 +1841,28 @@
 					<fo:table-row>
 						<fo:table-cell width="140mm">
 							<xsl:attribute name="padding-top">2mm</xsl:attribute>
-							<xsl:attribute name="padding-left">3mm</xsl:attribute>
+							<xsl:attribute name="padding-left">1mm</xsl:attribute>
 							<xsl:attribute name="padding-right">3mm</xsl:attribute>
 							<xsl:attribute name="padding-end">3mm</xsl:attribute>
 		
 							<fo:block>
-								<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-									<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
-								</xsl:if>
+								<xsl:choose> 
+									<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+										<xsl:attribute name="margin-left">0mm</xsl:attribute>
+									</xsl:when>
+									<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
+										<xsl:attribute name="margin-left">0mm</xsl:attribute>
+									</xsl:when>
+									<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_task']">
+										<xsl:attribute name="margin-left">0mm</xsl:attribute>
+									</xsl:when>
+									<xsl:when test="ancestor::extension[@extension_name='loop_area']">
+										<xsl:attribute name="margin-left">13.5mm</xsl:attribute>
+									</xsl:when>
+									<xsl:otherwise>
+										<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
+									</xsl:otherwise>
+								</xsl:choose> 
 								<xsl:apply-templates></xsl:apply-templates>
 							</fo:block>
 						</fo:table-cell>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -677,42 +677,48 @@
 							</xsl:otherwise>
 						</xsl:choose> 
 					</fo:table-column>
-					<fo:table-body>		
-						<fo:table-row keep-together.within-column="auto">
-							<fo:table-cell number-columns-spanned="2">
-								<xsl:choose> 
-									<xsl:when test="ancestor::extension[@extension_name='loop_area']">
-										<xsl:attribute name="max-width">145mm</xsl:attribute>
-									</xsl:when>
-									<xsl:when test="ancestor::extension[@extension_name='spoiler']">
-										<xsl:attribute name="max-width">140mm</xsl:attribute>
-									</xsl:when>
-									<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
-										<xsl:attribute name="max-width">140mm</xsl:attribute>
-									</xsl:when>
-									<xsl:otherwise>
-										<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
-									</xsl:otherwise>
-								</xsl:choose> 
-								<fo:block text-align="left" margin-bottom="1mm">
+					<fo:table-body>	
+						<xsl:if test="not($object[@extension_name='loop_task'])">
+							<fo:table-row keep-together.within-column="auto">
+								<fo:table-cell number-columns-spanned="2">
 									<xsl:choose> 
-										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
-											<xsl:attribute name="margin-left">0mm</xsl:attribute>
-										</xsl:when>
-										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
-											<xsl:attribute name="margin-left">0mm</xsl:attribute>
-										</xsl:when>
 										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
-											<xsl:attribute name="margin-left">13mm</xsl:attribute>
+											<xsl:attribute name="max-width">145mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+											<xsl:attribute name="max-width">140mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
+											<xsl:attribute name="max-width">140mm</xsl:attribute>
 										</xsl:when>
 										<xsl:otherwise>
 											<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
 										</xsl:otherwise>
 									</xsl:choose> 
-									<xsl:apply-templates/><!-- mode="loop_object"-->
-								</fo:block>
-							</fo:table-cell>	
-						</fo:table-row>
+									<fo:block text-align="left" margin-bottom="1mm">
+										<xsl:choose> 
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_task']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area']">
+													<xsl:attribute name="margin-left">13.5mm</xsl:attribute>
+												</xsl:when>
+												<xsl:otherwise>
+													<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
+												</xsl:otherwise>
+										</xsl:choose> 
+										<xsl:apply-templates/><!-- mode="loop_object"-->
+									</fo:block>
+								</fo:table-cell>	
+							</fo:table-row>
+						</xsl:if>
+						
 						<xsl:if test="count($object[@render]) = 0 or $object[@render!='none']">
 							<fo:table-row keep-together.within-column="auto" >
 								<fo:table-cell width="0.4mm" background-color="{$accent_color}">
@@ -729,10 +735,13 @@
 									<xsl:call-template name="font_object_title"></xsl:call-template>
 									<fo:block text-align="left">
 									<xsl:choose> 
-										<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
 											<xsl:attribute name="margin-left">0mm</xsl:attribute>
 										</xsl:when>
-										<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
+											<xsl:attribute name="margin-left">0mm</xsl:attribute>
+										</xsl:when>
+										<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_task']">
 											<xsl:attribute name="margin-left">0mm</xsl:attribute>
 										</xsl:when>
 										<xsl:when test="ancestor::extension[@extension_name='loop_area']">
@@ -889,6 +898,47 @@
 								</fo:table-cell>
 							</fo:table-row>
 						</xsl:if>
+						
+							<xsl:if test="@extension_name='loop_task'">		
+								<fo:table-row keep-together.within-column="auto">
+									<fo:table-cell number-columns-spanned="2">
+										<xsl:choose> 
+											<xsl:when test="ancestor::extension[@extension_name='loop_area']">
+												<xsl:attribute name="max-width">145mm</xsl:attribute>
+											</xsl:when>
+											<xsl:when test="ancestor::extension[@extension_name='spoiler']">
+												<xsl:attribute name="max-width">140mm</xsl:attribute>
+											</xsl:when>
+											<xsl:when test="ancestor::extension[@extension_name='loop_spoiler']">
+												<xsl:attribute name="max-width">140mm</xsl:attribute>
+											</xsl:when>
+											<xsl:otherwise>
+												<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
+											</xsl:otherwise>
+										</xsl:choose> 
+										<fo:block text-align="left" margin-bottom="1mm">
+											<xsl:choose> 
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_spoiler']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='spoiler']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area'] and ancestor::extension[@extension_name='loop_task']">
+													<xsl:attribute name="margin-left">0mm</xsl:attribute>
+												</xsl:when>
+												<xsl:when test="ancestor::extension[@extension_name='loop_area']">
+													<xsl:attribute name="margin-left">13.5mm</xsl:attribute>
+												</xsl:when>
+												<xsl:otherwise>
+													<!-- <xsl:attribute name="margin-left">0mm</xsl:attribute> -->
+												</xsl:otherwise>
+											</xsl:choose> 
+											<xsl:apply-templates/><!-- mode="loop_object"-->
+										</fo:block>
+									</fo:table-cell>	
+								</fo:table-row>
+							</xsl:if>
 					</fo:table-body>
 				</fo:table>
 			</fo:block>
@@ -1752,7 +1802,7 @@
 	<xsl:template name="spoiler">
 	<xsl:choose>
 		<xsl:when test="not(@noprint='true')">
-			<fo:block keep-together.within-page="auto">
+			<fo:block keep-together.within-page="always">
 				<fo:block font-weight="bold" width="145mm">
 					<fo:inline wrap-option="no-wrap" axf:border-top-left-radius="1mm" axf:border-top-right-radius="1mm" padding-left="1.3mm" padding-right="1.3mm" padding-top="1.3mm" padding-bottom="1.5mm">
 

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -1832,7 +1832,7 @@
 		
 							<fo:block>
 								<xsl:if test="ancestor::extension[@extension_name='loop_area']">
-									<!--<xsl:attribute name="margin-left">12.5mm</xsl:attribute> -->
+									<xsl:attribute name="margin-left">12.5mm</xsl:attribute>
 								</xsl:if>
 								<xsl:apply-templates></xsl:apply-templates>
 							</fo:block>


### PR DESCRIPTION
- Objekttitel werden nun escaped (zufällige HTML-Entities konnten erkannt werden)
- Mathe in Spoilern funktioniert nun zuverlässig
- Aufgabenauszeichnungen tauchen nun über dem Inhalt auf
- Bei deaktivierter Seitennummerierung wird die Nummer nicht mehr in Verzeichnissen angezeigt
- Shared basic wird jetzt in allen funktionen berücksichtigt, die auch shared user betreffen
- PDF: Literaturverzeichnis läuft wieder.
- PDF: Spoiler haben nun wieder noprint option
- PDF: spans für Texthervorhebungen hinzugefügt
- PDF: Loop_zoom hinzugefügt
