### PR TITLE
Seitenbereich loop_area im pdf: Icon und Text werden getrennt

### DIFF
--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2059,7 +2059,7 @@
 
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">
-		<fo:table keep-together.within-page="auto" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
+		<fo:table keep-together.within-page="always" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
 			<fo:table-column column-number="1" column-width="10mm" />
 			<fo:table-column column-number="2" column-width="6mm" margin-right="-10mm"/>
 			<fo:table-column column-number="3" column-width="146mm"/>

--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2059,13 +2059,13 @@
 
 	<!-- Loop Area -->
 	<xsl:template match="extension[@extension_name='loop_area']" name="looparea">
-		<fo:table keep-together.within-page="always" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
+		<fo:table keep-together.within-page="auto" table-layout="auto" margin-left="-12.5mm" border-style="solid" border-width="0pt" border-color="black" border-collapse="collapse"  padding-start="0pt" padding-end="0pt" padding-top="0pt" padding-bottom="0pt"  padding-right="0pt" >
 			<fo:table-column column-number="1" column-width="10mm" />
 			<fo:table-column column-number="2" column-width="6mm" margin-right="-10mm"/>
 			<fo:table-column column-number="3" column-width="146mm"/>
 			<fo:table-body>
 				<fo:table-row>
-					<fo:table-cell width="10mm" text-align="center" color="{$accent_color}" >
+					<fo:table-cell keep-together.within-page="always" width="10mm" text-align="center" color="{$accent_color}" >
 						<fo:block>
 						<!-- ICON IMG -->
 						<fo:block font-size="25pt" padding-bottom="2mm" margin-top="1.6mm" >


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/13136581/234560751-286f8e33-e8cb-4102-8b17-0cda898050c8.png)

vs neu


![grafik](https://user-images.githubusercontent.com/13136581/234560860-9065912b-cea3-435f-8bbb-713375820bb1.png)
