### PR TITLE
Ausrichtung von Schmuckgrafiken im PDF anpassen

### DIFF
--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2290,7 +2290,7 @@
 									<xsl:attribute name="padding-right">6mm</xsl:attribute>
 								</xsl:when>
 								<xsl:when test="$align='end'">
-									<xsl:attribute name="padding-left">6mm</xsl:attribute>
+									<xsl:attribute name="padding-left">10mm</xsl:attribute>
 								</xsl:when>
 								<xsl:when test="$align='center'">
 									<!-- <xsl:attribute name="padding-bottom">7mm</xsl:attribute>				 -->


### PR DESCRIPTION
Padding-left von 6mm auf 10mm hochgesetzt.