### PR TITLE
Rel1 39 62 pdf

### DIFF
--- a/xsl/pdf.xsl
+++ b/xsl/pdf.xsl
@@ -2097,7 +2097,7 @@
 			<fo:table-body>
 				<fo:table-row>
 					<fo:table-cell width="10mm" text-align="center" color="{$accent_color}" > <!-- keep-together.within-page="always" -->
-						<fo:block>
+						<fo:block keep-together.within-page="always">
 						<!-- ICON IMG -->
 						<fo:block font-size="25pt" padding-bottom="2mm" margin-top="1.6mm" >
 							<xsl:choose>


### PR DESCRIPTION
Use the <fo:block> attribute keep-together.within-page to keep the loop_area icon and its text togehter